### PR TITLE
fix: fix bug with boosts

### DIFF
--- a/methods.ts
+++ b/methods.ts
@@ -1172,7 +1172,7 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier of the target user */
     user_id: number;
-  }): UserChatBoosts[];
+  }): UserChatBoosts;
 
   /** Use this method to change the list of the bot's commands. See https://core.telegram.org/bots#commands for more details about bot commands. Returns True on success. */
   setMyCommands(args: {


### PR DESCRIPTION
there is a bug with boosts

when I call
```
const boosts = await bot.telegram.getUserChatBoosts(channelId, userId);
console.log("boosts", boosts);
```

it should log me an array, but actually it logs me:
```
boosts {
    boosts: [
        // my boosts...
    ]
}
```