### PR TITLE
feat: API 9.1 & 9.2

### DIFF
--- a/inline.ts
+++ b/inline.ts
@@ -683,7 +683,7 @@ export interface InputInvoiceMessageContent {
   provider_token?: string;
   /** Three-letter ISO 4217 currency code, see more on currencies. Pass “XTR” for payments in Telegram Stars. */
   currency: string;
-  /** Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.). Must contain exactly one item for payments in Telegram Stars. */
+  /** Price breakdown, a list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.). Must contain exactly one item for payments in Telegram Stars. */
   prices: LabeledPrice[];
   /** Optional. The maximum accepted amount for tips in the smallest units of the currency (integer, not float/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0. Not supported for payments in Telegram Stars. */
   max_tip_amount?: number;

--- a/manage.ts
+++ b/manage.ts
@@ -103,6 +103,8 @@ export declare namespace Chat {
     title: string;
     /** True, if the supergroup chat is a forum (has topics enabled) */
     is_forum?: true;
+    /** True, if the chat is the direct messages chat of a channel */
+    is_direct_messages?: true;
   }
 
   /** Internal type representing channel chats. */
@@ -226,6 +228,8 @@ declare namespace ChatFullInfo {
     photo?: ChatPhoto;
     /** If non-empty, the list of all active chat usernames; for private chats, supergroups and channels */
     active_usernames?: string[];
+    /** Information about the corresponding channel chat; for direct messages chats only */
+    parent_chat?: Chat.ChannelChat;
     /** List of available reactions allowed in the chat. If omitted, then all emoji reactions are allowed */
     available_reactions?: ReactionType[];
     /** Custom emoji identifier of the emoji chosen by the chat for the reply header and link preview background */
@@ -319,6 +323,40 @@ export type ChatFullInfo =
   | ChatFullInfo.SupergroupChat
   | ChatFullInfo.ChannelChat;
 
+/** Describes the price of a suggested post. */
+export interface SuggestedPostPrice {
+  /** Currency in which the post will be paid. Currently, must be one of “XTR” for Telegram Stars or “TON” for toncoins */
+  currency: string;
+  /** The amount of the currency that will be paid for the post in the smallest units of the currency, i.e. Telegram Stars or nanotoncoins. Currently, price in Telegram Stars must be between 5 and 100000, and price in nanotoncoins must be between 10000000 and 10000000000000. */
+  amount: number;
+}
+
+/** Contains information about a suggested post. */
+export interface SuggestedPostInfo {
+  /** State of the suggested post. Currently, it can be one of “pending”, “approved”, “declined”. */
+  state: "pending" | "approved" | "declined";
+  /** Proposed price of the post. If the field is omitted, then the post is unpaid. */
+  price?: SuggestedPostPrice;
+  /** Proposed send date of the post. If the field is omitted, then the post can be published at any time within 30 days at the sole discretion of the user or administrator who approves it. */
+  send_date?: number;
+}
+
+/** Contains parameters of a post that is being suggested by the bot. */
+export interface SuggestedPostParameters {
+  /** Proposed price for the post. If the field is omitted, then the post is unpaid. */
+  price?: SuggestedPostPrice;
+  /** Proposed send date of the post. If specified, then the date must be between 300 second and 2678400 seconds (30 days) in the future. If the field is omitted, then the post can be published at any time within 30 days at the sole discretion of the user who approves it. */
+  send_date?: number;
+}
+
+/** Describes a topic of a direct messages chat. */
+export interface DirectMessagesTopic {
+  /** Unique identifier of the topic */
+  topic_id: number;
+  /** Information about the user that created the topic. Currently, it is always present */
+  user: User;
+}
+
 /** This object represent a user's profile pictures. */
 export interface UserProfilePhotos {
   /** Total number of profile pictures the target user has */
@@ -369,7 +407,7 @@ export interface ChatInviteLink {
 export interface ChatAdministratorRights {
   /** True, if the user's presence in the chat is hidden */
   is_anonymous: boolean;
-  /** True, if the administrator can access the chat event log, get boost list, see hidden supergroup and channel members, report spam messages and ignore slow mode. Implied by any other administrator privilege. */
+  /** True, if the administrator can access the chat event log, get boost list, see hidden supergroup and channel members, report spam messages, ignore slow mode, and send messages to the chat without paying Telegram Stars. Implied by any other administrator privilege. */
   can_manage_chat: boolean;
   /** True, if the administrator can delete messages of other users */
   can_delete_messages: boolean;
@@ -389,7 +427,7 @@ export interface ChatAdministratorRights {
   can_edit_stories: boolean;
   /** True, if the administrator can delete stories posted by other users */
   can_delete_stories: boolean;
-  /** True, if the administrator can post messages in the channel, or access channel statistics; for channels only */
+  /** True, if the administrator can post messages in the channel, approve suggested posts, or access channel statistics; for channels only */
   can_post_messages: boolean;
   /** True, if the administrator can edit messages of other users and can pin messages; for channels only */
   can_edit_messages: boolean;
@@ -397,6 +435,8 @@ export interface ChatAdministratorRights {
   can_pin_messages: boolean;
   /** True, if the user is allowed to create, rename, close, and reopen forum topics; for supergroups only */
   can_manage_topics: boolean;
+  /** True, if the administrator can manage direct messages of the channel and decline suggested posts; for channels only */
+  can_manage_direct_messages: boolean;
 }
 
 /** This object contains information about one member of a chat. Currently, the following 6 types of chat members are supported:
@@ -437,7 +477,7 @@ export interface ChatMemberAdministrator extends AbstractChatMember {
   can_be_edited: boolean;
   /** True, if the user's presence in the chat is hidden */
   is_anonymous: boolean;
-  /** True, if the administrator can access the chat event log, get boost list, see hidden supergroup and channel members, report spam messages and ignore slow mode. Implied by any other administrator privilege. */
+  /** True, if the administrator can access the chat event log, get boost list, see hidden supergroup and channel members, report spam messages, ignore slow mode, and send messages to the chat without paying Telegram Stars. Implied by any other administrator privilege. */
   can_manage_chat: boolean;
   /** True, if the administrator can delete messages of other users */
   can_delete_messages: boolean;
@@ -457,7 +497,7 @@ export interface ChatMemberAdministrator extends AbstractChatMember {
   can_edit_stories: boolean;
   /** True, if the administrator can delete stories posted by other users */
   can_delete_stories: boolean;
-  /** True, if the administrator can post messages in the channel, or access channel statistics; for channels only */
+  /** True, if the administrator can post messages in the channel, approve suggested posts, or access channel statistics; for channels only */
   can_post_messages: boolean;
   /** True, if the administrator can edit messages of other users and can pin messages; for channels only */
   can_edit_messages: boolean;
@@ -465,6 +505,8 @@ export interface ChatMemberAdministrator extends AbstractChatMember {
   can_pin_messages: boolean;
   /** True, if the user is allowed to create, rename, close, and reopen forum topics; for supergroups only */
   can_manage_topics: boolean;
+  /** True, if the administrator can manage direct messages of the channel and decline suggested posts; for channels only */
+  can_manage_direct_messages: boolean;
   /** Custom title for this user */
   custom_title?: string;
 }
@@ -495,7 +537,7 @@ export interface ChatMemberRestricted extends AbstractChatMember {
   can_send_video_notes: boolean;
   /** True, if the user is allowed to send voice notes */
   can_send_voice_notes: boolean;
-  /** True, if the user is allowed to send polls */
+  /** True, if the user is allowed to send polls and checklists */
   can_send_polls: boolean;
   /** True, if the user is allowed to send animations, games, stickers and use inline bots */
   can_send_other_messages: boolean;
@@ -577,7 +619,7 @@ export interface ChatPermissions {
   can_send_video_notes?: boolean;
   /** True, if the user is allowed to send voice notes */
   can_send_voice_notes?: boolean;
-  /** True, if the user is allowed to send polls */
+  /** True, if the user is allowed to send polls and checklists */
   can_send_polls?: boolean;
   /** True, if the user is allowed to send animations, games, stickers and use inline bots */
   can_send_other_messages?: boolean;
@@ -756,7 +798,7 @@ export interface AbstractReactionType {
 }
 
 // deno-fmt-ignore
-export type TelegramEmoji = "👍" | "👎" | "❤" | "🔥" | "🥰" | "👏" | "😁" | "🤔" | "🤯" | "😱" | "🤬" | "😢" | "🎉" | "🤩" | "🤮" | "💩" | "🙏" | "👌" | "🕊" | "🤡" | "🥱" | "🥴" | "😍" | "🐳" | "❤‍🔥" | "🌚" | "🌭" | "💯" | "🤣" | "⚡" | "🍌" | "🏆" | "💔" | "🤨" | "😐" | "🍓" | "🍾" | "💋" | "🖕" | "😈" | "😴" | "😭" | "🤓" | "👻" | "👨‍💻" | "👀" | "🎃" | "🙈" | "😇" | "😨" | "🤝" | "✍" | "🤗" | "🫡" | "🎅" | "🎄" | "☃" | "💅" | "🤪" | "🗿" | "🆒" | "💘" | "🙉" | "🦄" | "😘" | "💊" | "🙊" | "😎" | "👾" | "🤷‍♂" | "🤷" | "🤷‍♀" | "😡";
+export type TelegramEmoji = "❤" | "👍" | "👎" | "🔥" | "🥰" | "👏" | "😁" | "🤔" | "🤯" | "😱" | "🤬" | "😢" | "🎉" | "🤩" | "🤮" | "💩" | "🙏" | "👌" | "🕊" | "🤡" | "🥱" | "🥴" | "😍" | "🐳" | "❤‍🔥" | "🌚" | "🌭" | "💯" | "🤣" | "⚡" | "🍌" | "🏆" | "💔" | "🤨" | "😐" | "🍓" | "🍾" | "💋" | "🖕" | "😈" | "😴" | "😭" | "🤓" | "👻" | "👨‍💻" | "👀" | "🎃" | "🙈" | "😇" | "😨" | "🤝" | "✍" | "🤗" | "🫡" | "🎅" | "🎄" | "☃" | "💅" | "🤪" | "🗿" | "🆒" | "💘" | "🙉" | "🦄" | "😘" | "💊" | "🙊" | "😎" | "👾" | "🤷‍♂" | "🤷" | "🤷‍♀" | "😡";
 
 /** The reaction is based on an emoji. */
 export interface ReactionTypeEmoji extends AbstractReactionType {
@@ -1029,6 +1071,8 @@ export interface Gift {
   total_count?: number;
   /** The number of remaining gifts of this type that can be sent; for limited gifts only */
   remaining_count?: number;
+  /** Information about the chat that published the gift */
+  publisher_chat?: Chat;
 }
 
 /** This object represent a list of gifts. */
@@ -1093,6 +1137,8 @@ export interface UniqueGift {
   symbol: UniqueGiftSymbol;
   /** Backdrop of the gift */
   backdrop: UniqueGiftBackdrop;
+  /** Information about the chat that published the gift */
+  publisher_chat?: Chat;
 }
 
 /** This object describes a gift received and owned by a user or a chat. Currently, it can be one of
@@ -1148,6 +1194,8 @@ export interface OwnedGiftUnique {
   can_be_transferred?: boolean;
   /** Number of Telegram Stars that must be paid to transfer the gift; omitted if the bot cannot transfer the gift */
   transfer_star_count?: number;
+  /** Point in time (Unix timestamp) when the gift can be transferred. If it is in the past, then the gift can be transferred now */
+  next_transfer_date?: number;
 }
 
 /** Contains the list of gifts received and owned by a user or a chat. */

--- a/markup.ts
+++ b/markup.ts
@@ -29,19 +29,19 @@ export declare namespace InlineKeyboardButton {
     login_url: LoginUrl;
   }
   export interface SwitchInlineButton extends AbstractInlineKeyboardButton {
-    /** If set, pressing the button will prompt the user to select one of their chats, open that chat and insert the bot's username and the specified inline query in the input field. May be empty, in which case just the bot's username will be inserted. Not supported for messages sent on behalf of a Telegram Business account. */
+    /** If set, pressing the button will prompt the user to select one of their chats, open that chat and insert the bot's username and the specified inline query in the input field. May be empty, in which case just the bot's username will be inserted. Not supported for messages sent in channel direct messages chats and on behalf of a Telegram Business account. */
     switch_inline_query: string;
   }
   export interface SwitchInlineCurrentChatButton
     extends AbstractInlineKeyboardButton {
     /** If set, pressing the button will insert the bot's username and the specified inline query in the current chat's input field. May be empty, in which case only the bot's username will be inserted.
 
-    This offers a quick way for the user to open your bot in inline mode in the same chat - good for selecting something from multiple options. Not supported in channels and for messages sent on behalf of a Telegram Business account. */
+    This offers a quick way for the user to open your bot in inline mode in the same chat - good for selecting something from multiple options. Not supported for messages sent in channel direct messages chats and on behalf of a Telegram Business account. */
     switch_inline_query_current_chat: string;
   }
   export interface SwitchInlineChosenChatButton
     extends AbstractInlineKeyboardButton {
-    /** If set, pressing the button will prompt the user to select one of their chats of the specified type, open that chat and insert the bot's username and the specified inline query in the input field. Not supported for messages sent on behalf of a Telegram Business account. */
+    /** If set, pressing the button will prompt the user to select one of their chats of the specified type, open that chat and insert the bot's username and the specified inline query in the input field. Not supported for messages sent in channel direct messages chats and on behalf of a Telegram Business account. */
     switch_inline_query_chosen_chat: SwitchInlineQueryChosenChat;
   }
   export interface CopyTextButton extends AbstractInlineKeyboardButton {

--- a/methods.ts
+++ b/methods.ts
@@ -24,6 +24,7 @@ import type {
   ReactionType,
   StarAmount,
   StoryArea,
+  SuggestedPostParameters,
   UserChatBoosts,
   UserFromGetMe,
   UserProfilePhotos,
@@ -31,6 +32,7 @@ import type {
 } from "./manage.ts";
 import type {
   GameHighScore,
+  InputChecklist,
   LinkPreviewOptions,
   MaskPosition,
   Message,
@@ -96,7 +98,7 @@ export type ApiMethods<F> = {
     allowed_updates?: ReadonlyArray<Exclude<UnionKeys<Update>, "update_id">>;
   }): Update[];
 
-  /** Use this method to specify a URL and receive incoming updates via an outgoing webhook. Whenever there is an update for the bot, we will send an HTTPS POST request to the specified URL, containing a JSON-serialized Update. In case of an unsuccessful request (a request with response HTTP status code different from 2XY), we will repeat the request and give up after a reasonable amount of attempts. Returns True on success.
+  /** Use this method to specify a URL and receive incoming updates via an outgoing webhook. Whenever there is an update for the bot, we will send an HTTPS POST request to the specified URL, containing an Update. In case of an unsuccessful request (a request with response HTTP status code different from 2XY), we will repeat the request and give up after a reasonable amount of attempts. Returns True on success.
 
   If you'd like to make sure that the webhook was set by you, you can specify secret data in the parameter secret_token. If specified, the request will contain a header “X-Telegram-Bot-Api-Secret-Token” with the secret token as content.
 
@@ -151,6 +153,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Text of the message to be sent, 1-4096 characters after entities parsing */
     text: string;
     /** Mode for parsing entities in the message text. See formatting options for more details. */
@@ -167,6 +171,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. A object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -183,6 +189,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Unique identifier for the chat where the original message was sent (or channel username in the format `@channelusername`) */
     from_chat_id: number | string;
     /** New start timestamp for the forwarded video in the message */
@@ -191,6 +199,8 @@ export type ApiMethods<F> = {
     disable_notification?: boolean;
     /** Protects the contents of the forwarded message from forwarding and saving */
     protect_content?: boolean;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Message identifier in the chat specified in from_chat_id */
     message_id: number;
   }): Message & Message.BusinessSentMessage;
@@ -201,6 +211,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Unique identifier for the chat where the original messages were sent (or channel username in the format `@channelusername`) */
     from_chat_id: number | string;
     /** A list of 1-100 identifiers of messages in the chat from_chat_id to forward. The identifiers must be specified in a strictly increasing order. */
@@ -217,6 +229,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Unique identifier for the chat where the original message was sent (or channel username in the format `@channelusername`) */
     from_chat_id: number | string;
     /** Message identifier in the chat specified in from_chat_id */
@@ -237,6 +251,8 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Pass True to allow up to 1000 messages per second, ignoring broadcasting limits for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance */
     allow_paid_broadcast?: boolean;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -253,6 +269,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Unique identifier for the chat where the original messages were sent (or channel username in the format `@channelusername`) */
     from_chat_id: number | string;
     /** A list of 1-100 identifiers of messages in the chat from_chat_id to copy. The identifiers must be specified in a strictly increasing order. */
@@ -273,6 +291,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Photo to send. Pass a file_id as String to send a photo that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a photo from the Internet, or upload a new photo using multipart/form-data. The photo must be at most 10 MB in size. The photo's width and height must not exceed 10000 in total. Width and height ratio must be at most 20. */
     photo: F | string;
     /** Photo caption (may also be used when resending photos by file_id), 0-1024 characters after entities parsing */
@@ -291,6 +311,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -311,6 +333,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Audio file to send. Pass a file_id as String to send an audio file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get an audio file from the Internet, or upload a new one using multipart/form-data. */
     audio: F | string;
     /** Audio caption, 0-1024 characters after entities parsing */
@@ -335,6 +359,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -353,6 +379,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** File to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. */
     document: F | string;
     /** Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Thumbnails can't be reused and can be only uploaded as a new file. Use Telegraf's [Input helpers](https://telegraf.js.org/modules/Input.html) to upload a new thumbnail. */
@@ -373,6 +401,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -391,6 +421,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Video to send. Pass a file_id as String to send a video that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a video from the Internet, or upload a new video using multipart/form-data. */
     video: F | string;
     /** Duration of sent video in seconds */
@@ -425,6 +457,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -443,6 +477,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Animation to send. Pass a file_id as String to send an animation that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get an animation from the Internet, or upload a new animation using multipart/form-data. */
     animation: F | string;
     /** Duration of sent animation in seconds */
@@ -471,6 +507,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -489,6 +527,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Audio file to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. */
     voice: F | string;
     /** Voice message caption, 0-1024 characters after entities parsing */
@@ -507,6 +547,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -526,6 +568,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Video note to send. Pass a file_id as String to send a video note that exists on the Telegram servers (recommended) or upload a new video using multipart/form-data.. Sending video notes by a URL is currently unsupported */
     video_note: F | string;
     /** Duration of sent video in seconds */
@@ -542,6 +586,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -558,6 +604,10 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`). If the chat is a channel, all Telegram Star proceeds from this media will be credited to the chat's balance. Otherwise, they will be credited to the bot's balance. */
     chat_id: number | string;
+    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** The number of Telegram Stars that must be paid to buy access to the media; 1-10000 */
     star_count: number;
     /** An array describing the media to be sent; up to 10 items */
@@ -578,6 +628,8 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Pass True to allow up to 1000 messages per second, ignoring broadcasting limits for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance */
     allow_paid_broadcast?: boolean;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -588,7 +640,7 @@ export type ApiMethods<F> = {
       | ForceReply;
   }): Message.PaidMediaMessage & Message.BusinessSentMessage;
 
-  /** Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned. */
+  /** Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files can be only grouped in an album with messages of the same type. On success, an array of Message objects that were sent is returned. */
   sendMediaGroup(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
@@ -596,6 +648,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** An array describing messages to be sent, must include 2-10 items */
     media: ReadonlyArray<
       | InputMediaAudio<F>
@@ -630,6 +684,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Latitude of the location */
     latitude: number;
     /** Longitude of the location */
@@ -650,6 +706,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -668,6 +726,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Latitude of the venue */
     latitude: number;
     /** Longitude of the venue */
@@ -692,6 +752,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -710,6 +772,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Contact's phone number */
     phone_number: string;
     /** Contact's first name */
@@ -726,6 +790,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -740,7 +806,7 @@ export type ApiMethods<F> = {
   sendPoll(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`). Polls can't be sent to channel direct messages chats. */
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
@@ -748,9 +814,9 @@ export type ApiMethods<F> = {
     question: string;
     /** Mode for parsing entities in the question. See formatting options for more details. Currently, only custom emoji entities are allowed */
     question_parse_mode?: ParseMode;
-    /** A JSON-serialized list of special entities that appear in the poll question. It can be specified instead of question_parse_mode */
+    /** A list of special entities that appear in the poll question. It can be specified instead of question_parse_mode */
     question_entities?: MessageEntity[];
-    /** A list of answer options, 2-10 answer options */
+    /** A list of answer options, 2-12 answer options */
     options: readonly InputPollOption[];
     /** True, if the poll needs to be anonymous, defaults to True */
     is_anonymous?: boolean;
@@ -790,6 +856,30 @@ export type ApiMethods<F> = {
       | ForceReply;
   }): Message.PollMessage & Message.BusinessSentMessage;
 
+  /** Use this method to send a checklist on behalf of a connected business account. On success, the sent Message is returned. */
+  sendChecklist(args: {
+    /** Unique identifier of the business connection on behalf of which the message will be sent */
+    business_connection_id?: string;
+    /** Unique identifier for the target chat */
+    chat_id: number | string;
+    /** An object for the checklist to send */
+    checklist: InputChecklist;
+    /** Sends the message silently. Users will receive a notification with no sound. */
+    disable_notification?: boolean;
+    /** Protects the contents of the sent message from forwarding and saving */
+    protect_content?: boolean;
+    /** Unique identifier of the message effect to be added to the message */
+    message_effect_id?: string;
+    /** An object for description of the message to reply to */
+    reply_parameters?: ReplyParameters;
+    /** An object for an inline keyboard */
+    reply_markup?:
+      | InlineKeyboardMarkup
+      | ReplyKeyboardMarkup
+      | ReplyKeyboardRemove
+      | ForceReply;
+  }): Message.ChecklistMessage & Message.BusinessSentMessage;
+
   /** Use this method to send an animated emoji that will display a random value. On success, the sent Message is returned. */
   sendDice(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
@@ -798,6 +888,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Emoji on which the dice throw animation is based. Currently, must be one of "🎲", "🎯", "🏀", "⚽", "🎳", or "🎰". Dice can have values 1-6 for "🎲", "🎯" and "🎳", values 1-5 for "🏀" and "⚽", and values 1-64 for "🎰". Defaults to "🎲" */
     emoji?: string;
     /** Sends the message silently. Users will receive a notification with no sound. */
@@ -808,6 +900,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -826,7 +920,7 @@ export type ApiMethods<F> = {
   sendChatAction(args: {
     /** Unique identifier of the business connection on behalf of which the action will be sent */
     business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`). Channel chats and channel direct messages chats aren't supported. */
     chat_id: number | string;
     /** Unique identifier for the target message thread; for supergroups only */
     message_thread_id?: number;
@@ -854,7 +948,7 @@ export type ApiMethods<F> = {
     /** A list of reaction types to set on the message. Currently, as non-premium users, bots can set up to one reaction per message. A custom emoji reaction can be used if it is either already present on the message or explicitly allowed by chat administrators. Paid reactions can't be used by bots. */
     reaction?: ReactionType[];
     /** Pass True to set the reaction with a big animation */
-    is_big?: Boolean;
+    is_big?: boolean;
   }): true;
 
   /** Use this method to get a list of profile pictures for a user. Returns a UserProfilePhotos object. */
@@ -913,7 +1007,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to restrict a user in a supergroup. The bot must be an administrator in the supergroup for this to work and must have the appropriate administrator rights. Pass True for all permissions to lift restrictions from a user. Returns True on success. */
   restrictChatMember(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier of the target user */
     user_id: number;
@@ -933,7 +1027,7 @@ export type ApiMethods<F> = {
     user_id: number;
     /** Pass True if the administrator's presence in the chat is hidden */
     is_anonymous?: boolean;
-    /** Pass True if the administrator can access the chat event log, get boost list, see hidden supergroup and channel members, report spam messages and ignore slow mode. Implied by any other administrator privilege. */
+    /** Pass True if the administrator can access the chat event log, get boost list, see hidden supergroup and channel members, report spam messages, ignore slow mode, and send messages to the chat without paying Telegram Stars. Implied by any other administrator privilege. */
     can_manage_chat?: boolean;
     /** Pass True if the administrator can delete messages of other users */
     can_delete_messages?: boolean;
@@ -961,11 +1055,13 @@ export type ApiMethods<F> = {
     can_pin_messages?: boolean;
     /** Pass True if the user is allowed to create, rename, close, and reopen forum topics; supergroups only */
     can_manage_topics?: boolean;
+    /** Pass True if the administrator can manage direct messages within the channel and decline suggested posts; for channels only */
+    can_manage_direct_messages?: boolean;
   }): true;
 
   /** Use this method to set a custom title for an administrator in a supergroup promoted by the bot. Returns True on success. */
   setChatAdministratorCustomTitle(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier of the target user */
     user_id: number;
@@ -991,7 +1087,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to set default chat permissions for all members. The bot must be an administrator in the group or a supergroup for this to work and must have the can_restrict_members administrator rights. Returns True on success. */
   setChatPermissions(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** An object for new default chat permissions */
     permissions: ChatPermissions;
@@ -1113,7 +1209,7 @@ export type ApiMethods<F> = {
     description?: string;
   }): true;
 
-  /** Use this method to add a message to the list of pinned messages in a chat. If the chat is not a private chat, the bot must be an administrator in the chat for this to work and must have the 'can_pin_messages' admin right in a supergroup or 'can_edit_messages' admin right in a channel. Returns True on success. */
+  /** Use this method to add a message to the list of pinned messages in a chat. In private chats and channel direct messages chats, all non-service messages can be pinned. Conversely, the bot must be an administrator with the 'can_pin_messages' right or the 'can_edit_messages' right to pin messages in groups and channels respectively. Returns True on success. */
   pinChatMessage(args: {
     /** Unique identifier of the business connection on behalf of which the message will be pinned */
     business_connection_id?: string;
@@ -1125,7 +1221,7 @@ export type ApiMethods<F> = {
     disable_notification?: boolean;
   }): true;
 
-  /** Use this method to remove a message from the list of pinned messages in a chat. If the chat is not a private chat, the bot must be an administrator in the chat for this to work and must have the 'can_pin_messages' admin right in a supergroup or 'can_edit_messages' admin right in a channel. Returns True on success. */
+  /** Use this method to remove a message from the list of pinned messages in a chat. In private chats and channel direct messages chats, all messages can be unpinned. Conversely, the bot must be an administrator with the 'can_pin_messages' right or the 'can_edit_messages' right to unpin messages in groups and channels respectively. Returns True on success. */
   unpinChatMessage(args: {
     /** Unique identifier of the business connection on behalf of which the message will be pinned */
     business_connection_id?: string;
@@ -1135,7 +1231,7 @@ export type ApiMethods<F> = {
     message_id?: number;
   }): true;
 
-  /** Use this method to clear the list of pinned messages in a chat. If the chat is not a private chat, the bot must be an administrator in the chat for this to work and must have the 'can_pin_messages' admin right in a supergroup or 'can_edit_messages' admin right in a channel. Returns True on success. */
+  /** Use this method to clear the list of pinned messages in a chat. In private chats and channel direct messages chats, no additional rights are required to unpin all pinned messages. Conversely, the bot must be an administrator with the 'can_pin_messages' right or the 'can_edit_messages' right to unpin all pinned messages in groups and channels respectively. Returns True on success. */
   unpinAllChatMessages(args: {
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
@@ -1143,7 +1239,7 @@ export type ApiMethods<F> = {
 
   /** Use this method for your bot to leave a group, supergroup or channel. Returns True on success. */
   leaveChat(args: {
-    /** Unique identifier for the target chat or username of the target supergroup or channel (in the format `@channelusername`) */
+    /** Unique identifier for the target chat or username of the target supergroup or channel (in the format `@channelusername`). Channel direct messages chats aren't supported; leave the corresponding channel instead. */
     chat_id: number | string;
   }): true;
 
@@ -1179,7 +1275,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to set a new group sticker set for a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Use the field can_set_sticker_set ly returned in getChat requests to check if the bot can use this method. Returns True on success. */
   setChatStickerSet(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Name of the sticker set to be set as the group sticker set */
     sticker_set_name: string;
@@ -1187,7 +1283,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to delete a group sticker set from a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Use the field can_set_sticker_set ly returned in getChat requests to check if the bot can use this method. Returns True on success. */
   deleteChatStickerSet(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
   }): true;
 
@@ -1195,7 +1291,7 @@ export type ApiMethods<F> = {
   getForumTopicIconStickers(): Sticker[];
   /** Use this method to create a topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns information about the created topic as a ForumTopic object. */
   createForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Topic name, 1-128 characters */
     name: string;
@@ -1213,7 +1309,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to edit name and icon of a topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic. Returns True on success. */
   editForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread of the forum topic */
     message_thread_id: number;
@@ -1225,7 +1321,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to close an open topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic. Returns True on success. */
   closeForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread of the forum topic */
     message_thread_id: number;
@@ -1233,7 +1329,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to reopen a closed topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic. Returns True on success. */
   reopenForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread of the forum topic */
     message_thread_id: number;
@@ -1241,7 +1337,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to delete a forum topic along with all its messages in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_delete_messages administrator rights. Returns True on success. */
   deleteForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread of the forum topic */
     message_thread_id: number;
@@ -1249,7 +1345,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to clear the list of pinned messages in a forum topic. The bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup. Returns True on success. */
   unpinAllForumTopicMessages(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** Unique identifier for the target message thread of the forum topic */
     message_thread_id: number;
@@ -1257,7 +1353,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to edit the name of the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have can_manage_topics administrator rights. Returns True on success. */
   editGeneralForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
     /** New topic name, 1-128 characters */
     name: string;
@@ -1265,31 +1361,31 @@ export type ApiMethods<F> = {
 
   /** Use this method to close an open 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns True on success. */
   closeGeneralForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
   }): true;
 
   /** Use this method to reopen a closed 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. The topic will be automatically unhidden if it was hidden. Returns True on success. */
   reopenGeneralForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
   }): true;
 
   /** Use this method to hide the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. The topic will be automatically closed if it was open. Returns True on success. */
   hideGeneralForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
   }): true;
 
   /** Use this method to unhide the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns True on success. */
   unhideGeneralForumTopic(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
   }): true;
 
   /** Use this method to clear the list of pinned messages in a General forum topic. The bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup. Returns True on success. */
   unpinAllGeneralForumTopicMessages(args: {
-    /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+    /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
   }): true;
   /** Use this method to send answers to callback queries sent from inline keyboards. The answer will be displayed to the user as a notification at the top of the chat screen or as an alert. On success, True is returned.
@@ -1419,186 +1515,6 @@ export type ApiMethods<F> = {
     for_channels?: boolean;
   }): ChatAdministratorRights;
 
-  /** Use this method to edit text and game messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned. Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent. */
-  editMessageText(args: {
-    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
-    business_connection_id?: string;
-    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
-    chat_id?: number | string;
-    /** Required if inline_message_id is not specified. Identifier of the message to edit */
-    message_id?: number;
-    /** Required if chat_id and message_id are not specified. Identifier of the inline message */
-    inline_message_id?: string;
-    /** New text of the message, 1-4096 characters after entities parsing */
-    text: string;
-    /** Mode for parsing entities in the message text. See formatting options for more details. */
-    parse_mode?: ParseMode;
-    /** A list of special entities that appear in message text, which can be specified instead of parse_mode */
-    entities?: MessageEntity[];
-    /** Link preview generation options for the message */
-    link_preview_options?: LinkPreviewOptions;
-    /** An object for an inline keyboard. */
-    reply_markup?: InlineKeyboardMarkup;
-  }):
-    | (Update.Edited & Message.TextMessage & Message.BusinessSentMessage)
-    | true;
-
-  /** Use this method to edit captions of messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned. Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent. */
-  editMessageCaption(args: {
-    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
-    business_connection_id?: string;
-    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
-    chat_id?: number | string;
-    /** Required if inline_message_id is not specified. Identifier of the message to edit */
-    message_id?: number;
-    /** Required if chat_id and message_id are not specified. Identifier of the inline message */
-    inline_message_id?: string;
-    /** New caption of the message, 0-1024 characters after entities parsing */
-    caption?: string;
-    /** Mode for parsing entities in the message caption. See formatting options for more details. */
-    parse_mode?: ParseMode;
-    /** A list of special entities that appear in the caption, which can be specified instead of parse_mode */
-    caption_entities?: MessageEntity[];
-    /** Pass True, if the caption must be shown above the message media. Supported only for animation, photo and video messages. */
-    show_caption_above_media?: boolean;
-    /** An object for an inline keyboard. */
-    reply_markup?: InlineKeyboardMarkup;
-  }):
-    | (Update.Edited & Message.CaptionableMessage & Message.BusinessSentMessage)
-    | true;
-
-  /** Use this method to edit animation, audio, document, photo, or video messages, or to add media to text messages. If a message is part of a message album, then it can be edited only to an audio for audio albums, only to a document for document albums and to a photo or a video otherwise. When an inline message is edited, a new file can't be uploaded; use a previously uploaded file via its file_id or specify a URL. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned. Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent. */
-  editMessageMedia(args: {
-    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
-    business_connection_id?: string;
-    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
-    chat_id?: number | string;
-    /** Required if inline_message_id is not specified. Identifier of the message to edit */
-    message_id?: number;
-    /** Required if chat_id and message_id are not specified. Identifier of the inline message */
-    inline_message_id?: string;
-    /** An object for a new media content of the message */
-    media: InputMedia<F>;
-    /** An object for a new inline keyboard. */
-    reply_markup?: InlineKeyboardMarkup;
-  }): (Update.Edited & Message & Message.BusinessSentMessage) | true;
-
-  /** Use this method to edit live location messages. A location can be edited until its live_period expires or editing is explicitly disabled by a call to stopMessageLiveLocation. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned. */
-  editMessageLiveLocation(args: {
-    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
-    business_connection_id?: string;
-    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
-    chat_id?: number | string;
-    /** Required if inline_message_id is not specified. Identifier of the message to edit */
-    message_id?: number;
-    /** Required if chat_id and message_id are not specified. Identifier of the inline message */
-    inline_message_id?: string;
-    /** Latitude of new location */
-    latitude: number;
-    /** Longitude of new location */
-    longitude: number;
-    /** New period in seconds during which the location can be updated, starting from the message send date. If 0x7FFFFFFF is specified, then the location can be updated forever. Otherwise, the new value must not exceed the current live_period by more than a day, and the live location expiration date must remain within the next 90 days. If not specified, then live_period remains unchanged */
-    live_period?: number;
-    /** The radius of uncertainty for the location, measured in meters; 0-1500 */
-    horizontal_accuracy?: number;
-    /** The direction in which user is moving, in degrees; 1-360. For active live locations only. */
-    heading?: number;
-    /** The maximum distance for proximity alerts about approaching another chat member, in meters. For sent live locations only. */
-    proximity_alert_radius?: number;
-    /** An object for a new inline keyboard. */
-    reply_markup?: InlineKeyboardMarkup;
-  }):
-    | (Update.Edited & Message.LocationMessage & Message.BusinessSentMessage)
-    | true;
-
-  /** Use this method to stop updating a live location message before live_period expires. On success, if the message is not an inline message, the edited Message is returned, otherwise True is returned. */
-  stopMessageLiveLocation(args: {
-    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
-    business_connection_id?: string;
-    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
-    chat_id?: number | string;
-    /** Required if inline_message_id is not specified. Identifier of the message with live location to stop */
-    message_id?: number;
-    /** Required if chat_id and message_id are not specified. Identifier of the inline message */
-    inline_message_id?: string;
-    /** An object for a new inline keyboard. */
-    reply_markup?: InlineKeyboardMarkup;
-  }):
-    | (Update.Edited & Message.LocationMessage & Message.BusinessSentMessage)
-    | true;
-
-  /** Use this method to edit only the reply markup of messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned. Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent. */
-  editMessageReplyMarkup(args: {
-    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
-    business_connection_id?: string;
-    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
-    chat_id?: number | string;
-    /** Required if inline_message_id is not specified. Identifier of the message to edit */
-    message_id?: number;
-    /** Required if chat_id and message_id are not specified. Identifier of the inline message */
-    inline_message_id?: string;
-    /** An object for an inline keyboard. */
-    reply_markup?: InlineKeyboardMarkup;
-  }): (Update.Edited & Message & Message.BusinessSentMessage) | true;
-
-  /** Use this method to stop a poll which was sent by the bot. On success, the stopped Poll is returned. */
-  stopPoll(args: {
-    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
-    business_connection_id?: string;
-    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
-    chat_id: number | string;
-    /** Identifier of the original message with the poll */
-    message_id: number;
-    /** An object for a new message inline keyboard. */
-    reply_markup?: InlineKeyboardMarkup;
-  }): Poll;
-
-  /** Use this method to delete a message, including service messages, with the following limitations:
-  - A message can only be deleted if it was sent less than 48 hours ago.
-  - Service messages about a supergroup, channel, or forum topic creation can't be deleted.
-  - A dice message in a private chat can only be deleted if it was sent more than 24 hours ago.
-  - Bots can delete outgoing messages in private chats, groups, and supergroups.
-  - Bots can delete incoming messages in private chats.
-  - Bots granted can_post_messages permissions can delete outgoing messages in channels.
-  - If the bot is an administrator of a group, it can delete any message there.
-  - If the bot has can_delete_messages permission in a supergroup or a channel, it can delete any message there.
-  Returns True on success. */
-  deleteMessage(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
-    chat_id: number | string;
-    /** Identifier of the message to delete */
-    message_id: number;
-  }): true;
-
-  /** Use this method to delete multiple messages simultaneously. If some of the specified messages can't be found, they are skipped. Returns True on success. */
-  deleteMessages(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
-    chat_id: number | string;
-    /** A list of 1-100 identifiers of messages to delete. See {@link ApiMethods.deleteMessage deleteMessage} for limitations on which messages can be deleted */
-    message_ids: number[];
-  }): true;
-
-  /** Returns the list of gifts that can be sent by the bot to users and channel chats. Requires no parameters. Returns a Gifts object. */
-  getAvailableGifts(): Gifts;
-
-  /** Sends a gift to the given user or channel chat. The gift can't be converted to Telegram Stars by the receiver. Returns True on success. */
-  sendGift(args: {
-    /** Required if chat_id is not specified. Unique identifier of the target user who will receive the gift */
-    user_id?: number;
-    /** Required if user_id is not specified. Unique identifier for the chat or username of the channel (in the format `@channelusername`) that will receive the gift */
-    chat_id?: number | string;
-    /** Identifier of the gift */
-    gift_id: string;
-    /** Pass True to pay for the gift upgrade from the bot's balance, thereby making the upgrade free for the receiver */
-    pay_for_upgrade?: boolean;
-    /** Text that will be shown along with the gift; 0-255 characters */
-    text?: string;
-    /** Mode for parsing entities in the text. See formatting options for more details. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored. */
-    text_parse_mode?: ParseMode;
-    /** A list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored. */
-    text_entities?: MessageEntity[];
-  }): true;
-
   /** Gifts a Telegram Premium subscription to the given user. Returns True on success. */
   giftPremiumSubscription(args: {
     /** Unique identifier of the target user who will receive a Telegram Premium subscription */
@@ -1611,7 +1527,7 @@ export type ApiMethods<F> = {
     text?: string;
     /** Mode for parsing entities in the text. See formatting options for more details. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored. */
     text_parse_mode?: ParseMode;
-    /** A JSON-serialized list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored. */
+    /** A list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored. */
     text_entities?: MessageEntity[];
   }): true;
 
@@ -1625,7 +1541,7 @@ export type ApiMethods<F> = {
 
   /** Verifies a chat on behalf of the organization which is represented by the bot. Returns True on success. */
   verifyChat(args: {
-    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`). Channel direct messages chats can't be verified. */
     chat_id: number | string;
     /** Custom description for the verification; 0-70 characters. Must be empty if the organization isn't allowed to provide a custom verification description. */
     custom_description?: string;
@@ -1653,7 +1569,7 @@ export type ApiMethods<F> = {
     message_id: number;
   }): true;
 
-  /** Delete messages on behalf of a business account. Requires the can_delete_outgoing_messages business bot right to delete messages sent by the bot itself, or the can_delete_all_messages business bot right to delete any message. Returns True on success. */
+  /** Delete messages on behalf of a business account. Requires the can_delete_sent_messages business bot right to delete messages sent by the bot itself, or the can_delete_all_messages business bot right to delete any message. Returns True on success. */
   deleteBusinessMessages(args: {
     /** Unique identifier of the business connection on behalf of which to delete the messages */
     business_connection_id: string;
@@ -1831,6 +1747,226 @@ export type ApiMethods<F> = {
     story_id: number;
   }): true;
 
+  /** Use this method to edit text and game messages in a chat. On success, the edited Message is returned. Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent. */
+  editMessageText(args: {
+    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
+    business_connection_id?: string;
+    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    chat_id?: number | string;
+    /** Required if inline_message_id is not specified. Identifier of the message to edit */
+    message_id?: number;
+    /** Required if chat_id and message_id are not specified. Identifier of the inline message */
+    inline_message_id?: undefined;
+    /** New text of the message, 1-4096 characters after entities parsing */
+    text: string;
+    /** Mode for parsing entities in the message text. See formatting options for more details. */
+    parse_mode?: ParseMode;
+    /** A list of special entities that appear in message text, which can be specified instead of parse_mode */
+    entities?: MessageEntity[];
+    /** Link preview generation options for the message */
+    link_preview_options?: LinkPreviewOptions;
+    /** An object for an inline keyboard. */
+    reply_markup?: InlineKeyboardMarkup;
+  }): Update.Edited & Message.TextMessage & Message.BusinessSentMessage;
+
+  /** Use this method to edit inline text and game messages. On success, True is returned. Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent. */
+  editMessageText(args: {
+    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
+    business_connection_id?: string;
+    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    chat_id?: undefined;
+    /** Required if inline_message_id is not specified. Identifier of the message to edit */
+    message_id?: undefined;
+    /** Required if chat_id and message_id are not specified. Identifier of the inline message */
+    inline_message_id?: string;
+    /** New text of the message, 1-4096 characters after entities parsing */
+    text: string;
+    /** Mode for parsing entities in the message text. See formatting options for more details. */
+    parse_mode?: ParseMode;
+    /** A list of special entities that appear in message text, which can be specified instead of parse_mode */
+    entities?: MessageEntity[];
+    /** Link preview generation options for the message */
+    link_preview_options?: LinkPreviewOptions;
+    /** An object for an inline keyboard. */
+    reply_markup?: InlineKeyboardMarkup;
+  }): true;
+
+  /** Use this method to edit captions of messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned. Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent. */
+  editMessageCaption(args: {
+    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
+    business_connection_id?: string;
+    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    chat_id?: number | string;
+    /** Required if inline_message_id is not specified. Identifier of the message to edit */
+    message_id?: number;
+    /** Required if chat_id and message_id are not specified. Identifier of the inline message */
+    inline_message_id?: string;
+    /** New caption of the message, 0-1024 characters after entities parsing */
+    caption?: string;
+    /** Mode for parsing entities in the message caption. See formatting options for more details. */
+    parse_mode?: ParseMode;
+    /** A list of special entities that appear in the caption, which can be specified instead of parse_mode */
+    caption_entities?: MessageEntity[];
+    /** Pass True, if the caption must be shown above the message media. Supported only for animation, photo and video messages. */
+    show_caption_above_media?: boolean;
+    /** An object for an inline keyboard. */
+    reply_markup?: InlineKeyboardMarkup;
+  }):
+    | (Update.Edited & Message.CaptionableMessage & Message.BusinessSentMessage)
+    | true;
+
+  /** Use this method to edit animation, audio, document, photo, or video messages, or to add media to text messages. If a message is part of a message album, then it can be edited only to an audio for audio albums, only to a document for document albums and to a photo or a video otherwise. When an inline message is edited, a new file can't be uploaded; use a previously uploaded file via its file_id or specify a URL. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned. Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent. */
+  editMessageMedia(args: {
+    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
+    business_connection_id?: string;
+    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    chat_id?: number | string;
+    /** Required if inline_message_id is not specified. Identifier of the message to edit */
+    message_id?: number;
+    /** Required if chat_id and message_id are not specified. Identifier of the inline message */
+    inline_message_id?: string;
+    /** An object for a new media content of the message */
+    media: InputMedia<F>;
+    /** An object for a new inline keyboard. */
+    reply_markup?: InlineKeyboardMarkup;
+  }): (Update.Edited & Message & Message.BusinessSentMessage) | true;
+
+  /** Use this method to edit live location messages. A location can be edited until its live_period expires or editing is explicitly disabled by a call to stopMessageLiveLocation. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned. */
+  editMessageLiveLocation(args: {
+    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
+    business_connection_id?: string;
+    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    chat_id?: number | string;
+    /** Required if inline_message_id is not specified. Identifier of the message to edit */
+    message_id?: number;
+    /** Required if chat_id and message_id are not specified. Identifier of the inline message */
+    inline_message_id?: string;
+    /** Latitude of new location */
+    latitude: number;
+    /** Longitude of new location */
+    longitude: number;
+    /** New period in seconds during which the location can be updated, starting from the message send date. If 0x7FFFFFFF is specified, then the location can be updated forever. Otherwise, the new value must not exceed the current live_period by more than a day, and the live location expiration date must remain within the next 90 days. If not specified, then live_period remains unchanged */
+    live_period?: number;
+    /** The radius of uncertainty for the location, measured in meters; 0-1500 */
+    horizontal_accuracy?: number;
+    /** The direction in which user is moving, in degrees; 1-360. For active live locations only. */
+    heading?: number;
+    /** The maximum distance for proximity alerts about approaching another chat member, in meters. For sent live locations only. */
+    proximity_alert_radius?: number;
+    /** An object for a new inline keyboard. */
+    reply_markup?: InlineKeyboardMarkup;
+  }):
+    | (Update.Edited & Message.LocationMessage & Message.BusinessSentMessage)
+    | true;
+
+  /** Use this method to stop updating a live location message before live_period expires. On success, if the message is not an inline message, the edited Message is returned, otherwise True is returned. */
+  stopMessageLiveLocation(args: {
+    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
+    business_connection_id?: string;
+    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    chat_id?: number | string;
+    /** Required if inline_message_id is not specified. Identifier of the message with live location to stop */
+    message_id?: number;
+    /** Required if chat_id and message_id are not specified. Identifier of the inline message */
+    inline_message_id?: string;
+    /** An object for a new inline keyboard. */
+    reply_markup?: InlineKeyboardMarkup;
+  }):
+    | (Update.Edited & Message.LocationMessage & Message.BusinessSentMessage)
+    | true;
+
+  /** Use this method to edit only the reply markup of messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned. Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent. */
+  editMessageReplyMarkup(args: {
+    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
+    business_connection_id?: string;
+    /** Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    chat_id?: number | string;
+    /** Required if inline_message_id is not specified. Identifier of the message to edit */
+    message_id?: number;
+    /** Required if chat_id and message_id are not specified. Identifier of the inline message */
+    inline_message_id?: string;
+    /** An object for an inline keyboard. */
+    reply_markup?: InlineKeyboardMarkup;
+  }): (Update.Edited & Message & Message.BusinessSentMessage) | true;
+
+  /** Use this method to stop a poll which was sent by the bot. On success, the stopped Poll is returned. */
+  stopPoll(args: {
+    /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
+    business_connection_id?: string;
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    chat_id: number | string;
+    /** Identifier of the original message with the poll */
+    message_id: number;
+    /** An object for a new message inline keyboard. */
+    reply_markup?: InlineKeyboardMarkup;
+  }): Poll;
+
+  /** Use this method to approve a suggested post in a direct messages chat. The bot must have the 'can_post_messages' administrator right in the corresponding channel chat. Returns True on success. */
+  approveSuggestedPost(args: {
+    /** Unique identifier for the target direct messages chat */
+    chat_id: number;
+    /** Identifier of a suggested post message to approve */
+    message_id: number;
+    /** Point in time (Unix timestamp) when the post is expected to be published; omit if the date has already been specified when the suggested post was created. If specified, then the date must be not more than 2678400 seconds (30 days) in the future */
+    send_date?: number;
+  }): true;
+
+  /** Use this method to decline a suggested post in a direct messages chat. The bot must have the 'can_manage_direct_messages' administrator right in the corresponding channel chat. Returns True on success. */
+  declineSuggestedPost(args: {
+    /** Unique identifier for the target direct messages chat */
+    chat_id: number;
+    /** Identifier of a suggested post message to decline */
+    message_id: number;
+    /** Comment for the creator of the suggested post; 0-128 characters */
+    comment?: string;
+  }): true;
+
+  /** Use this method to delete a message, including service messages, with the following limitations:
+  - A message can only be deleted if it was sent less than 48 hours ago.
+  - Service messages about a supergroup, channel, or forum topic creation can't be deleted.
+  - A dice message in a private chat can only be deleted if it was sent more than 24 hours ago.
+  - Bots can delete outgoing messages in private chats, groups, and supergroups.
+  - Bots can delete incoming messages in private chats.
+  - Bots granted can_post_messages permissions can delete outgoing messages in channels.
+  - If the bot is an administrator of a group, it can delete any message there.
+  - If the bot has can_delete_messages permission in a supergroup or a channel, it can delete any message there.
+  Returns True on success. */
+  deleteMessage(args: {
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    chat_id: number | string;
+    /** Identifier of the message to delete */
+    message_id: number;
+  }): true;
+
+  /** Use this method to delete multiple messages simultaneously. If some of the specified messages can't be found, they are skipped. Returns True on success. */
+  deleteMessages(args: {
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    chat_id: number | string;
+    /** A list of 1-100 identifiers of messages to delete. See {@link ApiMethods.deleteMessage deleteMessage} for limitations on which messages can be deleted */
+    message_ids: number[];
+  }): true;
+
+  /** Returns the list of gifts that can be sent by the bot to users and channel chats. Requires no parameters. Returns a Gifts object. */
+  getAvailableGifts(): Gifts;
+
+  /** Sends a gift to the given user or channel chat. The gift can't be converted to Telegram Stars by the receiver. Returns True on success. */
+  sendGift(args: {
+    /** Required if chat_id is not specified. Unique identifier of the target user who will receive the gift */
+    user_id?: number;
+    /** Required if user_id is not specified. Unique identifier for the chat or username of the channel (in the format `@channelusername`) that will receive the gift */
+    chat_id?: number | string;
+    /** Identifier of the gift */
+    gift_id: string;
+    /** Pass True to pay for the gift upgrade from the bot's balance, thereby making the upgrade free for the receiver */
+    pay_for_upgrade?: boolean;
+    /** Text that will be shown along with the gift; 0-255 characters */
+    text?: string;
+    /** Mode for parsing entities in the text. See formatting options for more details. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored. */
+    text_parse_mode?: ParseMode;
+    /** A list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored. */
+    text_entities?: MessageEntity[];
+  }): true;
+
   /** Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers. On success, the sent Message is returned. */
   sendSticker(args: {
     /** Unique identifier of the business connection on behalf of which the message will be sent */
@@ -1839,6 +1975,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Sticker to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a .WEBP sticker from the Internet, or upload a new .WEBP, .TGS, or .WEBM sticker using Telegraf's [Input helpers](https://telegraf.js.org/modules/Input.html). Video and animated stickers can't be sent via an HTTP URL. */
     sticker: F | string;
     /** Emoji associated with the sticker; only for just uploaded stickers */
@@ -1851,6 +1989,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** A object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** Additional interface options. An object for an inline keyboard, custom reply keyboard, instructions to remove a reply keyboard or to force a reply from the user */
@@ -2027,7 +2167,7 @@ export type ApiMethods<F> = {
   savePreparedInlineMessage(args: {
     /** Unique identifier of the target user that can use the prepared message */
     user_id: number;
-    /** A JSON-serialized object describing the message to be sent */
+    /** An object describing the message to be sent */
     result: InlineQueryResult;
     /** Pass True if the message can be sent to private chats with users */
     allow_user_chats?: boolean;
@@ -2045,6 +2185,8 @@ export type ApiMethods<F> = {
     chat_id: number | string;
     /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
     message_thread_id?: number;
+    /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
+    direct_messages_topic_id?: number;
     /** Product name, 1-32 characters */
     title: string;
     /** Product description, 1-255 characters */
@@ -2055,7 +2197,7 @@ export type ApiMethods<F> = {
     provider_token: string;
     /** Three-letter ISO 4217 currency code, see more on currencies. Pass “XTR” for payments in Telegram Stars. */
     currency: string;
-    /** Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.). Must contain exactly one item for payments in Telegram Stars. */
+    /** Price breakdown, a list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.). Must contain exactly one item for payments in Telegram Stars. */
     prices: readonly LabeledPrice[];
     /** The maximum accepted amount for tips in the smallest units of the currency (integer, not float/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0. Not supported for payments in Telegram Stars. */
     max_tip_amount?: number;
@@ -2095,6 +2237,8 @@ export type ApiMethods<F> = {
     allow_paid_broadcast?: boolean;
     /** Unique identifier of the message effect to be added to the message; for private chats only */
     message_effect_id?: string;
+    /** A object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
+    suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
     reply_parameters?: ReplyParameters;
     /** An object for an inline keyboard. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button. */
@@ -2115,7 +2259,7 @@ export type ApiMethods<F> = {
     provider_token: string;
     /** Three-letter ISO 4217 currency code, see more on currencies. Pass “XTR” for payments in Telegram Stars. */
     currency: string;
-    /** Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.). Must contain exactly one item for payments in Telegram Stars. */
+    /** Price breakdown, a list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.). Must contain exactly one item for payments in Telegram Stars. */
     prices: LabeledPrice[];
     /** The number of seconds the subscription will be active for before the next payment. The currency must be set to “XTR” (Telegram Stars) if the parameter is used. Currently, it must always be 2592000 (30 days) if specified. Any number of subscriptions can be active for a given bot at the same time, including multiple concurrent subscriptions from the same user. Subscription price must not exceed 2500 Telegram Stars. */
     subscription_period: 2592000;
@@ -2170,6 +2314,9 @@ export type ApiMethods<F> = {
     /** Required if ok is False. Error message in human readable form that explains the reason for failure to proceed with the checkout (e.g. "Sorry, somebody just bought the last of our amazing black T-shirts while you were busy filling out your payment details. Please choose a different color or garment!"). Telegram will display this message to the user. */
     error_message?: string;
   }): true;
+
+  /** A method to get the current Telegram Stars balance of the bot. Requires no parameters. On success, returns a StarAmount object. */
+  getMyStarBalance(): StarAmount;
 
   /** Returns the bot's Telegram Star transactions in chronological order. On success, returns a StarTransactions object. */
   getStarTransactions(args: {

--- a/settings.ts
+++ b/settings.ts
@@ -122,7 +122,7 @@ export interface BotCommandScopeAllChatAdministrators {
 export interface BotCommandScopeChat {
   /** Scope type, must be chat */
   type: "chat";
-  /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+  /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`). Channel direct messages chats and channel chats aren't supported. */
   chat_id: number | string;
 }
 
@@ -130,7 +130,7 @@ export interface BotCommandScopeChat {
 export interface BotCommandScopeChatAdministrators {
   /** Scope type, must be chat_administrators */
   type: "chat_administrators";
-  /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+  /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`). Channel direct messages chats and channel chats aren't supported. */
   chat_id: number | string;
 }
 
@@ -138,7 +138,7 @@ export interface BotCommandScopeChatAdministrators {
 export interface BotCommandScopeChatMember {
   /** Scope type, must be chat_member */
   type: "chat_member";
-  /** Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) */
+  /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`). Channel direct messages chats and channel chats aren't supported. */
   chat_id: number | string;
   /** Unique identifier of the target user */
   user_id: number;


### PR DESCRIPTION
Based on https://web.archive.org/web/20250920204215/https://core.telegram.org/bots/api

Methods editMessage to sendGift were relocated in the API docs, so were relocated in our types as well. In the future I look forward to combining all the type files into one, reflecting the absolute order of API docs. The current split is a legacy remnant of typegram.