### PR TITLE
Support Bot API 9.6 types

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6.0.2
       - run: npm ci --ignore-scripts
       - run: npm run prepare
       - name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - run : npm ci --ignore-scripts
-    - run : npm run prepare
-    - name: Publish to npm
-      run : |
-        npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-        npm publish --ignore-scripts --access=public
-      env :
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/checkout@v3
+      - run: npm ci --ignore-scripts
+      - run: npm run prepare
+      - name: Publish to npm
+        run: |
+          npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          npm publish --ignore-scripts --access=public
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Types for the Telegram Bot API
 
-[![Bot API Version](https://img.shields.io/badge/Bot%20API-v9.3-f36caf.svg?style=flat-square&logo=Telegram&labelColor=white&color=blue)](https://core.telegram.org/bots/api) [![NPM version](https://img.shields.io/npm/v/@telegraf/types?style=flat-square&logo=npm&labelColor=fff&color=c53635)](https://npmjs.com/package/@telegraf/types)
+[![Bot API Version](https://img.shields.io/badge/Bot%20API-v9.4-f36caf.svg?style=flat-square&logo=Telegram&labelColor=white&color=blue)](https://core.telegram.org/bots/api) [![NPM version](https://img.shields.io/npm/v/@telegraf/types?style=flat-square&logo=npm&labelColor=fff&color=c53635)](https://npmjs.com/package/@telegraf/types)
 
 This project keeps Telegram Bot API types updated for Telegraf. This project provides TypeScript types for the entire [Telegram Bot API](https://core.telegram.org/bots/api).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Types for the Telegram Bot API
 
-[![Bot API Version](https://img.shields.io/badge/Bot%20API-v9.2-f36caf.svg?style=flat-square&logo=Telegram&labelColor=white&color=blue)](https://core.telegram.org/bots/api) [![NPM version](https://img.shields.io/npm/v/@telegraf/types?style=flat-square&logo=npm&labelColor=fff&color=c53635)](https://npmjs.com/package/@telegraf/types)
+[![Bot API Version](https://img.shields.io/badge/Bot%20API-v9.3-f36caf.svg?style=flat-square&logo=Telegram&labelColor=white&color=blue)](https://core.telegram.org/bots/api) [![NPM version](https://img.shields.io/npm/v/@telegraf/types?style=flat-square&logo=npm&labelColor=fff&color=c53635)](https://npmjs.com/package/@telegraf/types)
 
 This project keeps Telegram Bot API types updated for Telegraf. This project provides TypeScript types for the entire [Telegram Bot API](https://core.telegram.org/bots/api).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Types for the Telegram Bot API
 
-[![Bot API Version](https://img.shields.io/badge/Bot%20API-v9.4-f36caf.svg?style=flat-square&logo=Telegram&labelColor=white&color=blue)](https://core.telegram.org/bots/api) [![NPM version](https://img.shields.io/npm/v/@telegraf/types?style=flat-square&logo=npm&labelColor=fff&color=c53635)](https://npmjs.com/package/@telegraf/types)
+[![Bot API Version](https://img.shields.io/badge/Bot%20API-v9.6-f36caf.svg?style=flat-square&logo=Telegram&labelColor=white&color=blue)](https://core.telegram.org/bots/api) [![NPM version](https://img.shields.io/npm/v/@telegraf/types?style=flat-square&logo=npm&labelColor=fff&color=c53635)](https://npmjs.com/package/@telegraf/types)
 
 This project keeps Telegram Bot API types updated for Telegraf. This project provides TypeScript types for the entire [Telegram Bot API](https://core.telegram.org/bots/api).
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,7 +2,7 @@
   "tasks": {
     "check": "deno cache --check=all index.ts",
     "dev": "deno fmt && deno lint && deno task check",
-    "backport": "deno run --no-prompt --allow-import=cdn.skypack.dev,deno.land --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.7.2/src/cli.ts tsconfig.json",
+    "backport": "deno run --no-prompt --allow-import=cdn.skypack.dev,deno.land,jsr.io --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.16.0/src/cli.ts tsconfig.json",
     "clean": "git clean -fX '*.d.ts'"
   },
   "fmt": { "proseWrap": "preserve" },

--- a/manage.ts
+++ b/manage.ts
@@ -183,7 +183,7 @@ declare namespace ChatFullInfo {
     pinned_message?: Message;
     /** Information about types of gifts that are accepted by the chat or by the corresponding user for private chats */
     accepted_gift_types?: AcceptedGiftTypes[];
-    /** The number of Telegram Stars a general user have to pay to send a message to the chat */
+    /** The number of Telegram Stars a general user has to pay to send a message to the chat */
     paid_message_star_count?: number;
     /** The time after which all messages sent to the chat will be automatically deleted; in seconds */
     message_auto_delete_time?: number;
@@ -224,7 +224,7 @@ declare namespace ChatFullInfo {
     permissions?: ChatPermissions;
     /** Information about types of gifts that are accepted by the chat or by the corresponding user for private chats */
     accepted_gift_types?: AcceptedGiftTypes[];
-    /** The number of Telegram Stars a general user have to pay to send a message to the chat */
+    /** The number of Telegram Stars a general user has to pay to send a message to the chat */
     paid_message_star_count?: number;
     /** The time after which all messages sent to the chat will be automatically deleted; in seconds */
     message_auto_delete_time?: number;
@@ -273,7 +273,7 @@ declare namespace ChatFullInfo {
     permissions?: ChatPermissions;
     /** Information about types of gifts that are accepted by the chat or by the corresponding user for private chats */
     accepted_gift_types?: AcceptedGiftTypes[];
-    /** The number of Telegram Stars a general user have to pay to send a message to the chat */
+    /** The number of Telegram Stars a general user has to pay to send a message to the chat */
     paid_message_star_count?: number;
     /** True, if paid media messages can be sent or forwarded to the channel chat. The field is available only for channel chats. */
     can_send_paid_media?: true;
@@ -330,7 +330,7 @@ declare namespace ChatFullInfo {
     pinned_message?: Message;
     /** Information about types of gifts that are accepted by the chat or by the corresponding user for private chats */
     accepted_gift_types?: AcceptedGiftTypes[];
-    /** The number of Telegram Stars a general user have to pay to send a message to the chat */
+    /** The number of Telegram Stars a general user has to pay to send a message to the chat */
     paid_message_star_count?: number;
     /** True, if paid media messages can be sent or forwarded to the channel chat. The field is available only for channel chats. */
     can_send_paid_media?: true;

--- a/manage.ts
+++ b/manage.ts
@@ -47,6 +47,8 @@ export interface User {
   is_premium?: true;
   /** True, if this user added the bot to the attachment menu */
   added_to_attachment_menu?: true;
+  /** True, if this user can manage bots */
+  can_manage_bots?: true;
 }
 
 /** This object represents a Telegram user or bot that was returned by `getMe`. */
@@ -468,6 +470,8 @@ export interface ChatAdministratorRights {
   can_pin_messages: boolean;
   /** True, if the user is allowed to create, rename, close, and reopen forum topics; for supergroups only */
   can_manage_topics: boolean;
+  /** True, if the administrator can manage tags; for supergroups only */
+  can_manage_tags?: boolean;
   /** True, if the administrator can manage direct messages of the channel and decline suggested posts; for channels only */
   can_manage_direct_messages: boolean;
 }
@@ -547,6 +551,8 @@ export interface ChatMemberAdministrator extends AbstractChatMember {
 /** Represents a chat member that has no additional privileges or restrictions. */
 export interface ChatMemberMember extends AbstractChatMember {
   status: "member";
+  /** Tag of the member in the chat */
+  tag?: string;
   /** Date when the user's subscription will expire; Unix time */
   until_date?: number;
 }
@@ -554,6 +560,8 @@ export interface ChatMemberMember extends AbstractChatMember {
 /** Represents a chat member that is under certain restrictions in the chat. Supergroups only. */
 export interface ChatMemberRestricted extends AbstractChatMember {
   status: "restricted";
+  /** Tag of the member in the chat */
+  tag?: string;
   /** True, if the user is a member of the chat at the moment of the request */
   is_member: boolean;
   /** True, if the user is allowed to send text messages, contacts, giveaways, giveaway winners, invoices, locations and venues */
@@ -584,6 +592,8 @@ export interface ChatMemberRestricted extends AbstractChatMember {
   can_pin_messages: boolean;
   /** True, if the user is allowed to create forum topics */
   can_manage_topics: boolean;
+  /** True, if the user is allowed to edit their tag */
+  can_edit_tag?: boolean;
   /** Date when restrictions will be lifted for this user; Unix time. If 0, then the user is restricted forever */
   until_date: number;
 }
@@ -666,6 +676,22 @@ export interface ChatPermissions {
   can_pin_messages?: boolean;
   /** True, if the user is allowed to create forum topics. If omitted defaults to the value of can_pin_messages */
   can_manage_topics?: boolean;
+  /** True, if the user is allowed to edit their tag */
+  can_edit_tag?: boolean;
+}
+
+/** This object contains information about the bot that was created to be managed by the current bot. */
+export interface ManagedBotCreated {
+  /** Information about the bot */
+  bot: User;
+}
+
+/** This object contains information about the creation, token update, or owner update of a bot that is managed by the current bot. */
+export interface ManagedBotUpdated {
+  /** User that created the bot */
+  user: User;
+  /** Information about the bot */
+  bot: User;
 }
 
 /** Describes the birthdate of a user. */

--- a/manage.ts
+++ b/manage.ts
@@ -47,8 +47,6 @@ export interface User {
   is_premium?: true;
   /** True, if this user added the bot to the attachment menu */
   added_to_attachment_menu?: true;
-  /** True, if this user can manage bots */
-  can_manage_bots?: true;
 }
 
 /** This object represents a Telegram user or bot that was returned by `getMe`. */
@@ -69,6 +67,8 @@ export interface UserFromGetMe extends User {
   has_topics_enabled?: boolean;
   /** True, if the bot allows users to create and delete topics in private chats. Returned only in getMe. */
   allows_users_to_create_topics?: boolean;
+  /** True, if other bots can be created to be controlled by the bot. Returned only in getMe. */
+  can_manage_bots?: boolean;
 }
 
 export declare namespace Chat {
@@ -470,7 +470,7 @@ export interface ChatAdministratorRights {
   can_pin_messages: boolean;
   /** True, if the user is allowed to create, rename, close, and reopen forum topics; for supergroups only */
   can_manage_topics: boolean;
-  /** True, if the administrator can manage tags; for supergroups only */
+  /** True, if the administrator can edit the tags of regular members; for groups and supergroups only */
   can_manage_tags?: boolean;
   /** True, if the administrator can manage direct messages of the channel and decline suggested posts; for channels only */
   can_manage_direct_messages: boolean;
@@ -542,7 +542,7 @@ export interface ChatMemberAdministrator extends AbstractChatMember {
   can_pin_messages: boolean;
   /** True, if the user is allowed to create, rename, close, and reopen forum topics; for supergroups only */
   can_manage_topics: boolean;
-  /** True, if the administrator can manage tags; for supergroups only */
+  /** True, if the administrator can edit the tags of regular members; for groups and supergroups only */
   can_manage_tags?: boolean;
   /** True, if the administrator can manage direct messages of the channel and decline suggested posts; for channels only */
   can_manage_direct_messages: boolean;

--- a/manage.ts
+++ b/manage.ts
@@ -542,6 +542,8 @@ export interface ChatMemberAdministrator extends AbstractChatMember {
   can_pin_messages: boolean;
   /** True, if the user is allowed to create, rename, close, and reopen forum topics; for supergroups only */
   can_manage_topics: boolean;
+  /** True, if the administrator can manage tags; for supergroups only */
+  can_manage_tags?: boolean;
   /** True, if the administrator can manage direct messages of the channel and decline suggested posts; for channels only */
   can_manage_direct_messages: boolean;
   /** Custom title for this user */

--- a/manage.ts
+++ b/manage.ts
@@ -1,4 +1,5 @@
 import type {
+  Audio,
   Location,
   Message,
   MessageEntity,
@@ -64,6 +65,8 @@ export interface UserFromGetMe extends User {
   has_main_web_app?: boolean;
   /** True, if the bot has forum topic mode enabled in private chats. Returned only in getMe. */
   has_topics_enabled?: boolean;
+  /** True, if the bot allows users to create and delete topics in private chats. Returned only in getMe. */
+  allows_users_to_create_topics?: boolean;
 }
 
 export declare namespace Chat {
@@ -152,6 +155,8 @@ declare namespace ChatFullInfo {
     personal_chat?: ChatFullInfo.ChannelChat;
     /** For private chats, the rating of the user if any */
     rating?: UserRating;
+    /** For private chats, the first audio added to the profile of the user */
+    first_profile_audio?: Audio;
     /** List of available reactions allowed in the chat. If omitted, then all emoji reactions are allowed. */
     available_reactions?: ReactionType[];
     /** Custom emoji identifier of emoji chosen by the chat for the reply header and link preview background */
@@ -383,6 +388,14 @@ export interface UserProfilePhotos {
   total_count: number;
   /** Requested profile pictures (in up to 4 sizes each) */
   photos: PhotoSize[][];
+}
+
+/** This object represents the audios displayed on a user's profile. */
+export interface UserProfileAudios {
+  /** Total number of profile audios for the target user */
+  total_count: number;
+  /** Requested profile audios */
+  audios: Audio[];
 }
 
 /** This object represents a chat photo. */
@@ -1044,6 +1057,18 @@ export interface ChatBoostRemoved {
   source: ChatBoostSource;
 }
 
+/** Describes a service message about the chat owner leaving the chat. */
+export interface ChatOwnerLeft {
+  /** The user which will be the new owner of the chat if the previous owner does not return to the chat */
+  new_owner?: User;
+}
+
+/** Describes a service message about an ownership change in the chat. */
+export interface ChatOwnerChanged {
+  /** The new owner of the chat */
+  new_owner: User;
+}
+
 /** This object represents a list of boosts added to a chat by a user. */
 export interface UserChatBoosts {
   /** The list of boosts added to the chat by the user */
@@ -1145,6 +1170,8 @@ export interface UniqueGiftModel {
   sticker: Sticker;
   /** The number of unique gifts that receive this model for every 1000 gifts upgraded */
   rarity_per_mille: number;
+  /** Rarity of the model if it is a crafted model. Currently, can be “uncommon”, “rare”, “epic”, or “legendary”. */
+  rarity?: "uncommon" | "rare" | "epic" | "legendary";
 }
 
 /** This object describes the symbol shown on the pattern of a unique gift. */
@@ -1213,6 +1240,8 @@ export interface UniqueGift {
   backdrop: UniqueGiftBackdrop;
   /** True, if the original regular gift was exclusively purchaseable by Telegram Premium subscribers */
   is_premium?: true;
+  /** True, if the gift was used to craft another gift and isn't available anymore */
+  is_burned?: true;
   /** True, if the gift is assigned from the TON blockchain and can't be resold or transferred in Telegram */
   is_from_blockchain?: true;
   /** The color scheme that can be used by the gift's owner for the chat's name, replies to messages and link previews; for business account gifts and gifts that are currently on sale only */

--- a/manage.ts
+++ b/manage.ts
@@ -62,6 +62,8 @@ export interface UserFromGetMe extends User {
   can_connect_to_business?: boolean;
   /** True, if the bot has a main Web App. Returned only in getMe. */
   has_main_web_app?: boolean;
+  /** True, if the bot has forum topic mode enabled in private chats. Returned only in getMe. */
+  has_topics_enabled?: boolean;
 }
 
 export declare namespace Chat {
@@ -148,6 +150,8 @@ declare namespace ChatFullInfo {
     business_opening_hours?: BusinessOpeningHours;
     /** For private chats, the personal channel of the user */
     personal_chat?: ChatFullInfo.ChannelChat;
+    /** For private chats, the rating of the user if any */
+    rating?: UserRating;
     /** List of available reactions allowed in the chat. If omitted, then all emoji reactions are allowed. */
     available_reactions?: ReactionType[];
     /** Custom emoji identifier of emoji chosen by the chat for the reply header and link preview background */
@@ -156,6 +160,8 @@ declare namespace ChatFullInfo {
     profile_accent_color_id?: number;
     /** Custom emoji identifier of the emoji chosen by the chat for its profile background */
     profile_background_custom_emoji_id?: string;
+    /** The color scheme based on a unique gift that must be used for the chat's name, message replies and link previews */
+    unique_gift_colors?: UniqueGiftColors;
     /** Custom emoji identifier of emoji status of the other party in a private chat */
     emoji_status_custom_emoji_id?: string;
     /** Expiration date of the emoji status of the other party in a private chat in Unix time, if any */
@@ -170,6 +176,8 @@ declare namespace ChatFullInfo {
     pinned_message?: Message;
     /** Information about types of gifts that are accepted by the chat or by the corresponding user for private chats */
     accepted_gift_types?: AcceptedGiftTypes[];
+    /** The number of Telegram Stars a general user have to pay to send a message to the chat */
+    paid_message_star_count?: number;
     /** The time after which all messages sent to the chat will be automatically deleted; in seconds */
     message_auto_delete_time?: number;
     /** True, if messages from the chat can't be forwarded to other chats */
@@ -193,6 +201,8 @@ declare namespace ChatFullInfo {
     profile_accent_color_id?: number;
     /** Custom emoji identifier of the emoji chosen by the chat for its profile background */
     profile_background_custom_emoji_id?: string;
+    /** The color scheme based on a unique gift that must be used for the chat's name, message replies and link previews */
+    unique_gift_colors?: UniqueGiftColors;
     /** Custom emoji identifier of the emoji status of the chat or the other party in a private chat */
     emoji_status_custom_emoji_id?: string;
     /** Expiration date of the emoji status of the chat or the other party in a private chat, in Unix time, if any */
@@ -207,6 +217,8 @@ declare namespace ChatFullInfo {
     permissions?: ChatPermissions;
     /** Information about types of gifts that are accepted by the chat or by the corresponding user for private chats */
     accepted_gift_types?: AcceptedGiftTypes[];
+    /** The number of Telegram Stars a general user have to pay to send a message to the chat */
+    paid_message_star_count?: number;
     /** The time after which all messages sent to the chat will be automatically deleted; in seconds */
     message_auto_delete_time?: number;
     /** True, if non-administrators can only get the list of bots and administrators in the chat */
@@ -238,6 +250,8 @@ declare namespace ChatFullInfo {
     profile_accent_color_id?: number;
     /** Custom emoji identifier of the emoji chosen by the chat for its profile background */
     profile_background_custom_emoji_id?: string;
+    /** The color scheme based on a unique gift that must be used for the chat's name, message replies and link previews */
+    unique_gift_colors?: UniqueGiftColors;
     /** True, if users need to join the supergroup before they can send messages */
     join_to_send_messages?: true;
     /** True, if all users directly joining the supergroup need to be approved by supergroup administrators */
@@ -252,6 +266,8 @@ declare namespace ChatFullInfo {
     permissions?: ChatPermissions;
     /** Information about types of gifts that are accepted by the chat or by the corresponding user for private chats */
     accepted_gift_types?: AcceptedGiftTypes[];
+    /** The number of Telegram Stars a general user have to pay to send a message to the chat */
+    paid_message_star_count?: number;
     /** True, if paid media messages can be sent or forwarded to the channel chat. The field is available only for channel chats. */
     can_send_paid_media?: true;
     /** For supergroups, the minimum allowed delay between consecutive messages sent by each unpriviledged user; in seconds */
@@ -297,6 +313,8 @@ declare namespace ChatFullInfo {
     profile_accent_color_id?: number;
     /** Custom emoji identifier of the emoji chosen by the chat for its profile background */
     profile_background_custom_emoji_id?: string;
+    /** The color scheme based on a unique gift that must be used for the chat's name, message replies and link previews */
+    unique_gift_colors?: UniqueGiftColors;
     /** Description, for groups, supergroups and channel chats */
     description?: string;
     /** Primary invite link, for groups, supergroups and channel chats */
@@ -305,6 +323,8 @@ declare namespace ChatFullInfo {
     pinned_message?: Message;
     /** Information about types of gifts that are accepted by the chat or by the corresponding user for private chats */
     accepted_gift_types?: AcceptedGiftTypes[];
+    /** The number of Telegram Stars a general user have to pay to send a message to the chat */
+    paid_message_star_count?: number;
     /** True, if paid media messages can be sent or forwarded to the channel chat. The field is available only for channel chats. */
     can_send_paid_media?: true;
     /** The time after which all messages sent to the chat will be automatically deleted; in seconds */
@@ -679,6 +699,18 @@ export interface BusinessOpeningHours {
   opening_hours: BusinessOpeningHoursInterval[];
 }
 
+/** This object describes the rating of a user based on their Telegram Star spendings. */
+export interface UserRating {
+  /** Current level of the user, indicating their reliability when purchasing digital goods and services. A higher level suggests a more trustworthy customer; a negative level is likely reason for concern. */
+  level: number;
+  /** Numerical value of the user's rating; the higher the rating, the better */
+  rating: number;
+  /** The rating value required to get the current level */
+  current_level_rating: number;
+  /** The rating value required to get to the next level; omitted if the maximum level was reached */
+  next_level_rating?: number;
+}
+
 /** Describes the position of a clickable area within a story. */
 export interface StoryAreaPosition {
   /** The abscissa of the area's center, as a percentage of the media width */
@@ -925,6 +957,8 @@ export interface ForumTopic {
   icon_color: number;
   /** Unique identifier of the custom emoji shown as the topic icon */
   icon_custom_emoji_id?: string;
+  /** True, if the name of the topic wasn't specified explicitly by its creator and likely needs to be changed by the bot */
+  is_name_implicit?: true;
 }
 
 /** This object represents a bot command. */
@@ -1057,6 +1091,16 @@ export interface File {
   file_path?: string;
 }
 
+/** This object describes the background of a gift. */
+export interface GiftBackground {
+  /** Center color of the background in RGB format */
+  center_color: number;
+  /** Edge color of the background in RGB format */
+  edge_color: number;
+  /** Text color of the background in RGB format */
+  text_color: number;
+}
+
 /** This object represents a gift that can be sent by the bot. */
 export interface Gift {
   /** Unique identifier of the gift */
@@ -1067,10 +1111,22 @@ export interface Gift {
   star_count: number;
   /** The number of Telegram Stars that must be paid to upgrade the gift to a unique one */
   upgrade_star_count?: number;
+  /** True, if the gift can only be purchased by Telegram Premium subscribers */
+  is_premium?: true;
+  /** True, if the gift can be used (after being upgraded) to customize a user's appearance */
+  has_colors?: true;
   /** The total number of the gifts of this type that can be sent; for limited gifts only */
   total_count?: number;
   /** The number of remaining gifts of this type that can be sent; for limited gifts only */
   remaining_count?: number;
+  /** The total number of gifts of this type that can be sent by the bot; for limited gifts only */
+  personal_total_count?: number;
+  /** The number of remaining gifts of this type that can be sent by the bot; for limited gifts only */
+  personal_remaining_count?: number;
+  /** Background of the gift */
+  background?: GiftBackground;
+  /** The total number of different unique gifts that can be obtained by upgrading the gift */
+  unique_gift_variant_count?: number;
   /** Information about the chat that published the gift */
   publisher_chat?: Chat;
 }
@@ -1123,8 +1179,26 @@ export interface UniqueGiftBackdrop {
   rarity_per_mille: number;
 }
 
+/** This object contains information about the color scheme for a user's name, message replies and link previews based on a unique gift. */
+export interface UniqueGiftColors {
+  /** Custom emoji identifier of the unique gift's model */
+  model_custom_emoji_id: string;
+  /** Custom emoji identifier of the unique gift's symbol */
+  symbol_custom_emoji_id: string;
+  /** Main color used in light themes; RGB format */
+  light_theme_main_color: number;
+  /** List of 1-3 additional colors used in light themes; RGB format */
+  light_theme_other_colors: number[];
+  /** Main color used in dark themes; RGB format */
+  dark_theme_main_color: number;
+  /** List of 1-3 additional colors used in dark themes; RGB format */
+  dark_theme_other_colors: number[];
+}
+
 /** This object describes a unique gift that was upgraded from a regular gift. */
 export interface UniqueGift {
+  /** Identifier of the regular gift from which the gift was upgraded */
+  gift_id: string;
   /** Human-readable name of the regular gift from which this unique gift was upgraded */
   base_name: string;
   /** Unique name of the gift. This name can be used in https://t.me/nft/... links and story areas */
@@ -1137,6 +1211,12 @@ export interface UniqueGift {
   symbol: UniqueGiftSymbol;
   /** Backdrop of the gift */
   backdrop: UniqueGiftBackdrop;
+  /** True, if the original regular gift was exclusively purchaseable by Telegram Premium subscribers */
+  is_premium?: true;
+  /** True, if the gift is assigned from the TON blockchain and can't be resold or transferred in Telegram */
+  is_from_blockchain?: true;
+  /** The color scheme that can be used by the gift's owner for the chat's name, replies to messages and link previews; for business account gifts and gifts that are currently on sale only */
+  colors?: UniqueGiftColors;
   /** Information about the chat that published the gift */
   publisher_chat?: Chat;
 }
@@ -1174,6 +1254,10 @@ export interface OwnedGiftRegular {
   convert_star_count?: number;
   /** Number of Telegram Stars that were paid by the sender for the ability to upgrade the gift */
   prepaid_upgrade_star_count?: number;
+  /** True, if the gift's upgrade was purchased after the gift was sent; for gifts received on behalf of business accounts only */
+  is_upgrade_separate?: true;
+  /** Unique number reserved for this gift when upgraded. See the number field in UniqueGift */
+  unique_gift_number?: number;
 }
 
 /** Describes a unique gift received and owned by a user or a chat. */
@@ -1218,6 +1302,8 @@ export interface AcceptedGiftTypes {
   unique_gifts: boolean;
   /** True, if a Telegram Premium subscription is accepted */
   premium_subscription: boolean;
+  /** True, if transfers of unique gifts from channels are accepted */
+  gifts_from_channels: boolean;
 }
 
 /** Describes an amount of Telegram Stars. */

--- a/manage.ts
+++ b/manage.ts
@@ -595,7 +595,7 @@ export interface ChatMemberRestricted extends AbstractChatMember {
   /** True, if the user is allowed to create forum topics */
   can_manage_topics: boolean;
   /** True, if the user is allowed to edit their tag */
-  can_edit_tag?: boolean;
+  can_edit_tag: boolean;
   /** Date when restrictions will be lifted for this user; Unix time. If 0, then the user is restricted forever */
   until_date: number;
 }

--- a/markup.ts
+++ b/markup.ts
@@ -168,7 +168,7 @@ Example: A user requests to change the bot's language, bot replies to the reques
 
 /** This object represents one button of the reply keyboard. At most one of the fields other than text, icon_custom_emoji_id, and style must be used to specify the type of the button. For simple text buttons, String can be used instead of this object to specify the button text. */
 export declare namespace KeyboardButton {
-  interface Common {
+  export interface Common {
     /** Text of the button. If none of the fields other than text, icon_custom_emoji_id, and style are used, it will be sent as a message when the button is pressed */
     text: string;
     /** Unique identifier of the custom emoji shown before the text of the button. Can only be used by bots that purchased additional usernames on Fragment or in the messages directly sent by the bot to private, group and supergroup chats if the owner of the bot has a Telegram Premium subscription. */
@@ -176,38 +176,47 @@ export declare namespace KeyboardButton {
     /** Style of the button. Must be one of “danger” (red), “success” (green) or “primary” (blue). If omitted, then an app-specific style is used. */
     style?: "danger" | "success" | "primary";
   }
+  export interface CommonButton extends Common {}
   export interface RequestUsers extends Common {
     /** If specified, pressing the button will open a list of suitable users. Identifiers of selected users will be sent to the bot in a “users_shared” service message. Available in private chats only. */
     request_users: KeyboardButtonRequestUsers;
   }
+  export interface RequestUsersButton extends RequestUsers {}
   export interface RequestChat extends Common {
     /** If specified, pressing the button will open a list of suitable chats. Tapping on a chat will send its identifier to the bot in a “chat_shared” service message. Available in private chats only. */
     request_chat: KeyboardButtonRequestChat;
   }
+  export interface RequestChatButton extends RequestChat {}
   export interface RequestManagedBot extends Common {
     /** If specified, pressing the button will ask the user to create and share a bot that will be managed by the current bot. */
     request_managed_bot: KeyboardButtonRequestManagedBot;
   }
+  export interface RequestManagedBotButton extends RequestManagedBot {}
   export interface RequestContact extends Common {
     /** If True, the user's phone number will be sent as a contact when the button is pressed. Available in private chats only. */
     request_contact: boolean;
   }
+  export interface RequestContactButton extends RequestContact {}
   export interface RequestLocation extends Common {
     /** If True, the user's current location will be sent when the button is pressed. Available in private chats only. */
     request_location: boolean;
   }
+  export interface RequestLocationButton extends RequestLocation {}
   export interface RequestPoll extends Common {
     /** If specified, the user will be asked to create a poll and send it to the bot when the button is pressed. Available in private chats only. */
     request_poll: KeyboardButtonPollType;
   }
+  export interface RequestPollButton extends RequestPoll {}
   export interface WebApp extends Common {
     /** If specified, the described Web App will be launched when the button is pressed. The Web App will be able to send a “web_app_data” service message. Available in private chats only. */
     web_app: WebAppInfo;
   }
+  export interface WebAppButton extends WebApp {}
 }
 
 /** This object represents one button of the reply keyboard. For simple text buttons, String can be used instead of this object to specify the button text. The optional fields web_app, request_user, request_chat, request_contact, request_location, and request_poll are mutually exclusive. */
 export type KeyboardButton =
+  | KeyboardButton.Common
   | KeyboardButton.RequestUsers
   | KeyboardButton.RequestChat
   | KeyboardButton.RequestManagedBot

--- a/markup.ts
+++ b/markup.ts
@@ -11,6 +11,10 @@ export declare namespace InlineKeyboardButton {
   interface AbstractInlineKeyboardButton {
     /** Label text on the button */
     text: string;
+    /** Unique identifier of the custom emoji shown before the text of the button. Can only be used by bots that purchased additional usernames on Fragment or in the messages directly sent by the bot to private, group and supergroup chats if the owner of the bot has a Telegram Premium subscription. */
+    icon_custom_emoji_id?: string;
+    /** Style of the button. Must be one of “danger” (red), “success” (green) or “primary” (blue). If omitted, then an app-specific style is used. */
+    style?: "danger" | "success" | "primary";
   }
   export interface UrlButton extends AbstractInlineKeyboardButton {
     /** HTTP or tg:// URL to be opened when the button is pressed. Links tg://user?id=<user_id> can be used to mention a user by their identifier without using a username, if this is allowed by their privacy settings. */
@@ -62,7 +66,7 @@ export declare namespace InlineKeyboardButton {
   }
 }
 
-/** This object represents one button of an inline keyboard. Exactly one of the optional fields must be used to specify type of the button. */
+/** This object represents one button of an inline keyboard. Exactly one of the fields other than text, icon_custom_emoji_id, and style must be used to specify the type of the button. */
 export type InlineKeyboardButton =
   | InlineKeyboardButton.CallbackButton
   | InlineKeyboardButton.GameButton
@@ -162,11 +166,15 @@ Example: A user requests to change the bot's language, bot replies to the reques
   selective?: boolean;
 }
 
-/** This object represents one button of the reply keyboard. At most one of the optional fields must be used to specify type of the button. For simple text buttons, String can be used instead of this object to specify the button text. */
+/** This object represents one button of the reply keyboard. At most one of the fields other than text, icon_custom_emoji_id, and style must be used to specify the type of the button. For simple text buttons, String can be used instead of this object to specify the button text. */
 export declare namespace KeyboardButton {
   interface Common {
-    /** Text of the button. If none of the optional fields are used, it will be sent as a message when the button is pressed */
+    /** Text of the button. If none of the fields other than text, icon_custom_emoji_id, and style are used, it will be sent as a message when the button is pressed */
     text: string;
+    /** Unique identifier of the custom emoji shown before the text of the button. Can only be used by bots that purchased additional usernames on Fragment or in the messages directly sent by the bot to private, group and supergroup chats if the owner of the bot has a Telegram Premium subscription. */
+    icon_custom_emoji_id?: string;
+    /** Style of the button. Must be one of “danger” (red), “success” (green) or “primary” (blue). If omitted, then an app-specific style is used. */
+    style?: "danger" | "success" | "primary";
   }
   export interface RequestUsers extends Common {
     /** If specified, pressing the button will open a list of suitable users. Identifiers of selected users will be sent to the bot in a “users_shared” service message. Available in private chats only. */

--- a/markup.ts
+++ b/markup.ts
@@ -188,7 +188,7 @@ export declare namespace KeyboardButton {
   }
   export interface RequestChatButton extends RequestChat {}
   export interface RequestManagedBot extends Common {
-    /** If specified, pressing the button will ask the user to create and share a bot that will be managed by the current bot. */
+    /** If specified, pressing the button will ask the user to create and share a bot that will be managed by the current bot. Available in private chats only. */
     request_managed_bot: KeyboardButtonRequestManagedBot;
   }
   export interface RequestManagedBotButton extends RequestManagedBot {}
@@ -214,7 +214,7 @@ export declare namespace KeyboardButton {
   export interface WebAppButton extends WebApp {}
 }
 
-/** This object represents one button of the reply keyboard. For simple text buttons, String can be used instead of this object to specify the button text. The optional fields web_app, request_user, request_chat, request_contact, request_location, and request_poll are mutually exclusive. */
+/** This object represents one button of the reply keyboard. For simple text buttons, String can be used instead of this object to specify the button text. The fields web_app, request_users, request_chat, request_managed_bot, request_contact, request_location, and request_poll are mutually exclusive. */
 export type KeyboardButton =
   | KeyboardButton.Common
   | KeyboardButton.RequestUsers

--- a/markup.ts
+++ b/markup.ts
@@ -184,6 +184,10 @@ export declare namespace KeyboardButton {
     /** If specified, pressing the button will open a list of suitable chats. Tapping on a chat will send its identifier to the bot in a “chat_shared” service message. Available in private chats only. */
     request_chat: KeyboardButtonRequestChat;
   }
+  export interface RequestManagedBot extends Common {
+    /** If specified, pressing the button will ask the user to create and share a bot that will be managed by the current bot. */
+    request_managed_bot: KeyboardButtonRequestManagedBot;
+  }
   export interface RequestContact extends Common {
     /** If True, the user's phone number will be sent as a contact when the button is pressed. Available in private chats only. */
     request_contact: boolean;
@@ -206,6 +210,7 @@ export declare namespace KeyboardButton {
 export type KeyboardButton =
   | KeyboardButton.RequestUsers
   | KeyboardButton.RequestChat
+  | KeyboardButton.RequestManagedBot
   | KeyboardButton.RequestPoll
   | KeyboardButton.RequestContact
   | KeyboardButton.RequestLocation
@@ -294,4 +299,20 @@ export interface KeyboardButtonRequestChat {
   request_username?: boolean;
   /** Pass True to request the chat's photo */
   request_photo?: boolean;
+}
+
+/** This object defines the parameters for the creation of a managed bot. */
+export interface KeyboardButtonRequestManagedBot {
+  /** Signed 32-bit identifier of the request. Must be unique within the message */
+  request_id: number;
+  /** Suggested name for the bot */
+  suggested_name?: string;
+  /** Suggested username for the bot */
+  suggested_username?: string;
+}
+
+/** Describes a keyboard button to be used by a user of a Mini App. */
+export interface PreparedKeyboardButton {
+  /** Unique identifier of the keyboard button */
+  id: string;
 }

--- a/message.ts
+++ b/message.ts
@@ -6,6 +6,7 @@ import type {
   DirectMessagesTopic,
   File,
   Gift,
+  ManagedBotCreated,
   StarAmount,
   SuggestedPostInfo,
   SuggestedPostPrice,
@@ -54,6 +55,8 @@ export declare namespace Message {
     reply_to_story?: Story;
     /** Identifier of the specific checklist task that is being replied to */
     reply_to_checklist_task_id?: number;
+    /** Persistent identifier of the specific poll option that is being replied to */
+    reply_to_poll_option_id?: string;
     /** Bot through which the message was sent */
     via_bot?: User;
     /** Date the message was last edited in Unix time */
@@ -251,6 +254,10 @@ export declare namespace Message {
     /** Service message: a chat was shared with the bot */
     chat_shared: ChatShared;
   }
+  export interface ManagedBotCreatedMessage extends ServiceMessage {
+    /** Service message: a managed bot was created */
+    managed_bot_created: ManagedBotCreated;
+  }
   export interface GiftMessage extends ServiceMessage {
     /** Service message: a regular gift was sent or received */
     gift: GiftInfo;
@@ -294,6 +301,14 @@ export declare namespace Message {
   export interface ChecklistTasksAddedMessage extends ServiceMessage {
     /** Service message: tasks were added to a checklist */
     checklist_tasks_added: ChecklistTasksAdded;
+  }
+  export interface PollOptionAddedMessage extends ServiceMessage {
+    /** Service message: an option was added to a poll */
+    poll_option_added: PollOptionAdded;
+  }
+  export interface PollOptionDeletedMessage extends ServiceMessage {
+    /** Service message: an option was deleted from a poll */
+    poll_option_deleted: PollOptionDeleted;
   }
   export interface DirectMessagePriceChangedMessage extends ServiceMessage {
     /** Service message: the price for paid messages in the corresponding direct messages chat of a channel has changed */
@@ -405,6 +420,7 @@ export type ServiceMessageBundle =
   | Message.SuccessfulPaymentMessage
   | Message.UsersSharedMessage
   | Message.ChatSharedMessage
+  | Message.ManagedBotCreatedMessage
   | Message.GiftMessage
   | Message.UniqueGiftMessage
   | Message.GiftUpgradeSentMessage
@@ -413,6 +429,8 @@ export type ServiceMessageBundle =
   | Message.PassportDataMessage
   | Message.ProximityAlertTriggeredMessage
   | Message.BoostAddedMessage
+  | Message.PollOptionAddedMessage
+  | Message.PollOptionDeletedMessage
   | Message.ForumTopicCreatedMessage
   | Message.ForumTopicEditedMessage
   | Message.ForumTopicClosedMessage
@@ -696,6 +714,9 @@ export declare namespace MessageEntity {
     /** For “custom_emoji” only, unique identifier of the custom emoji. Use getCustomEmojiStickers to get full information about the sticker */
     custom_emoji_id: string;
   }
+  export interface DateTime extends Abstract {
+    type: "date_time";
+  }
 }
 
 /** This object represents one special entity in a text message. For example, hashtags, usernames, URLs, etc. */
@@ -718,7 +739,8 @@ export type MessageEntity =
   | MessageEntity.PreMessage
   | MessageEntity.TextLink
   | MessageEntity.TextMention
-  | MessageEntity.CustomEmoji;
+  | MessageEntity.CustomEmoji
+  | MessageEntity.DateTime;
 
 /** This object contains information about the quoted part of a message that is replied to by the given message. */
 export interface TextQuote {
@@ -887,6 +909,8 @@ export interface ReplyParameters {
   quote_position?: number;
   /** Identifier of the specific checklist task to be replied to */
   checklist_task_id?: number;
+  /** Persistent identifier of the specific poll option to be replied to */
+  poll_option_id?: string;
 }
 
 /** This object describes the origin of a message. It can be one of
@@ -1186,7 +1210,7 @@ export interface InputChecklistTask {
   text: string;
   /** Mode for parsing entities in the text. See formatting options for more details. */
   parse_mode?: ParseMode;
-  /** List of special entities that appear in the text, which can be specified instead of parse_mode. Currently, only bold, italic, underline, strikethrough, spoiler, and custom_emoji entities are allowed. */
+  /** List of special entities that appear in the text, which can be specified instead of parse_mode. */
   text_entities?: (
     | MessageEntity.Bold
     | MessageEntity.Italic
@@ -1194,6 +1218,7 @@ export interface InputChecklistTask {
     | MessageEntity.Strikethrough
     | MessageEntity.Spoiler
     | MessageEntity.CustomEmoji
+    | MessageEntity.DateTime
   )[];
 }
 
@@ -1203,7 +1228,7 @@ export interface InputChecklist {
   title: string;
   /** Mode for parsing entities in the title. See formatting options for more details. */
   parse_mode?: ParseMode;
-  /** List of special entities that appear in the title, which can be specified instead of parse_mode. Currently, only bold, italic, underline, strikethrough, spoiler, and custom_emoji entities are allowed. */
+  /** List of special entities that appear in the title, which can be specified instead of parse_mode. */
   title_entities?: (
     | MessageEntity.Bold
     | MessageEntity.Italic
@@ -1211,6 +1236,7 @@ export interface InputChecklist {
     | MessageEntity.Strikethrough
     | MessageEntity.Spoiler
     | MessageEntity.CustomEmoji
+    | MessageEntity.DateTime
   )[];
   /** List of 1-30 tasks in the checklist */
   tasks: InputChecklistTask[];
@@ -1262,12 +1288,20 @@ export interface Dice {
 
 /** This object contains information about one answer option in a poll. */
 export interface PollOption {
+  /** Unique identifier of the option, persistent on option addition and deletion */
+  persistent_id: string;
   /** Option text, 1-100 characters */
   text: string;
   /** Special entities that appear in the option text. Currently, only custom emoji entities are allowed in poll option texts */
   text_entities?: MessageEntity.CustomEmoji[];
-  /** Number of users that voted for this option */
+  /** Number of users that voted for this option; may be 0 if unknown */
   voter_count: number;
+  /** User who added the option */
+  added_by_user?: User;
+  /** Chat that added the option */
+  added_by_chat?: Chat;
+  /** Point in time when the option was added */
+  addition_date?: number;
 }
 
 /** This object contains information about one answer option in a poll to be sent. */
@@ -1293,6 +1327,8 @@ export interface PollAnswer {
   user?: User;
   /** 0-based identifiers of answer options, chosen by the user. May be empty if the user retracted their vote. */
   option_ids: number[];
+  /** Persistent identifiers of chosen answer options. May be empty if the vote was retracted. */
+  option_persistent_ids: string[];
 }
 
 /** This object contains information about a poll. */
@@ -1315,8 +1351,10 @@ export interface Poll {
   type: "regular" | "quiz";
   /** True, if the poll allows multiple answers */
   allows_multiple_answers: boolean;
-  /** 0-based identifier of the correct answer option. Available only for polls in the quiz mode, which are closed, or was sent (not forwarded) by the bot or to the private chat with the bot. */
-  correct_option_id?: number;
+  /** True, if the poll allows to change the chosen answer options */
+  allows_revoting: boolean;
+  /** 0-based identifiers of the correct answer options. */
+  correct_option_ids?: number[];
   /** Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters */
   explanation?: string;
   /** Special entities like usernames, URLs, bot commands, etc. that appear in the explanation */
@@ -1325,6 +1363,34 @@ export interface Poll {
   open_period?: number;
   /** Point in time (Unix timestamp) when the poll will be automatically closed */
   close_date?: number;
+  /** Description of the poll; for polls inside the Message object only */
+  description?: string;
+  /** Special entities that appear in the poll description */
+  description_entities?: MessageEntity[];
+}
+
+/** Describes a service message about an option added to a poll. */
+export interface PollOptionAdded {
+  /** Message containing the poll to which the option was added, if known */
+  poll_message?: MaybeInaccessibleMessage;
+  /** Unique identifier of the added option */
+  option_persistent_id: string;
+  /** Option text */
+  option_text: string;
+  /** Special entities that appear in the option text */
+  option_text_entities?: MessageEntity[];
+}
+
+/** Describes a service message about an option deleted from a poll. */
+export interface PollOptionDeleted {
+  /** Message containing the poll from which the option was deleted, if known */
+  poll_message?: MaybeInaccessibleMessage;
+  /** Unique identifier of the deleted option */
+  option_persistent_id: string;
+  /** Option text */
+  option_text: string;
+  /** Special entities that appear in the option text */
+  option_text_entities?: MessageEntity[];
 }
 
 export declare namespace Location {

--- a/message.ts
+++ b/message.ts
@@ -1,5 +1,7 @@
 // deno-lint-ignore-file no-irregular-whitespace
 import type {
+  ChatOwnerChanged,
+  ChatOwnerLeft,
   Chat,
   DirectMessagesTopic,
   File,
@@ -180,6 +182,14 @@ export declare namespace Message {
   export interface LeftChatMemberMessage extends ServiceMessage {
     /** A member was removed from the group, information about them (this member may be the bot itself) */
     left_chat_member: User;
+  }
+  export interface ChatOwnerLeftMessage extends ServiceMessage {
+    /** Service message: chat owner has left */
+    chat_owner_left: ChatOwnerLeft;
+  }
+  export interface ChatOwnerChangedMessage extends ServiceMessage {
+    /** Service message: chat owner has changed */
+    chat_owner_changed: ChatOwnerChanged;
   }
   export interface NewChatTitleMessage extends ServiceMessage {
     /** A chat title was changed to this value */
@@ -379,6 +389,8 @@ export declare namespace Message {
 export type ServiceMessageBundle =
   | Message.NewChatMembersMessage
   | Message.LeftChatMemberMessage
+  | Message.ChatOwnerLeftMessage
+  | Message.ChatOwnerChangedMessage
   | Message.NewChatTitleMessage
   | Message.NewChatPhotoMessage
   | Message.DeleteChatPhotoMessage
@@ -1013,6 +1025,22 @@ export interface Story {
   id: number;
 }
 
+/** This object represents a video file of a specific quality. */
+export interface VideoQuality {
+  /** Identifier for this file, which can be used to download or reuse the file */
+  file_id: string;
+  /** Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file. */
+  file_unique_id: string;
+  /** Video width */
+  width: number;
+  /** Video height */
+  height: number;
+  /** Codec that was used to encode the video, for example, “h264”, “h265”, or “av01” */
+  codec: string;
+  /** File size in bytes. It can be bigger than 2^31 and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this value. */
+  file_size?: number;
+}
+
 /** This object represents a video file. */
 export interface Video {
   /** Identifier for this file, which can be used to download or reuse the file */
@@ -1031,6 +1059,8 @@ export interface Video {
   cover?: PhotoSize[];
   /** Timestamp in seconds from which the video will play in the message */
   start_timestamp?: number;
+  /** List of available qualities of the video */
+  qualities?: VideoQuality[];
   /** Original filename as defined by the sender */
   file_name?: string;
   /** MIME type of the file as defined by the sender */

--- a/message.ts
+++ b/message.ts
@@ -69,6 +69,8 @@ export declare namespace Message {
     is_paid_post?: true;
     /** Signature of the post author for messages in channels, or the custom title of an anonymous group administrator */
     author_signature?: string;
+    /** Tag of the sender of the message in the chat */
+    sender_tag?: string;
     /** The number of Telegram Stars that were paid by the sender of the message to send it */
     paid_star_count?: number;
     /** Options used for link preview generation for the message, if it is a text message and link preview options were changed */

--- a/message.ts
+++ b/message.ts
@@ -629,7 +629,7 @@ export type ParseMode = "Markdown" | "MarkdownV2" | "HTML";
 
 export declare namespace MessageEntity {
   interface Abstract {
-    /** Type of the entity. Currently, can be “mention” (@username), “hashtag” (#hashtag or #hashtag@chatusername), “cashtag” ($USD or $USD@chatusername), “bot_command” (/start@jobs_bot), “url” (https://telegram.org), “email” (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text), “spoiler” (spoiler message), “blockquote” (block quotation), “expandable_blockquote” (collapsed-by-default block quotation), “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users without usernames), “custom_emoji” (for inline custom emoji stickers) */
+    /** Type of the entity. Currently, can be “mention” (@username), “hashtag” (#hashtag or #hashtag@chatusername), “cashtag” ($USD or $USD@chatusername), “bot_command” (/start@jobs_bot), “url” (https://telegram.org), “email” (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text), “spoiler” (spoiler message), “blockquote” (block quotation), “expandable_blockquote” (collapsed-by-default block quotation), “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users without usernames), “custom_emoji” (for inline custom emoji stickers), or “date_time” (for formatted date and time) */
     type: string;
     /** Offset in UTF-16 code units to the start of the entity */
     offset: number;

--- a/message.ts
+++ b/message.ts
@@ -18,7 +18,7 @@ export declare namespace Message {
   export interface ServiceMessage {
     /** Unique message identifier inside this chat */
     message_id: number;
-    /** Unique identifier of a message thread or a forum topic to which the message belongs; for supergroups only */
+    /** Unique identifier of a message thread or forum topic to which the message belongs; for supergroups and private chats only */
     message_thread_id?: number;
     /** Sender of the message; empty for messages sent to channels. For backward compatibility, the field contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat. */
     /** Information about the direct messages chat topic that contains the message */
@@ -30,7 +30,7 @@ export declare namespace Message {
     date: number;
     /** Chat the message belongs to */
     chat: Chat;
-    /** True, if the message is sent to a forum topic */
+    /** True, if the message is sent to a topic in a forum supergroup or a private chat with the bot */
     is_topic_message?: boolean;
   }
   export interface CommonMessage extends ServiceMessage {
@@ -249,6 +249,10 @@ export declare namespace Message {
     /** Service message: a unique gift was sent or received */
     unique_gift: UniqueGiftInfo;
   }
+  export interface GiftUpgradeSentMessage extends ServiceMessage {
+    /** Service message: upgrade of a gift was purchased after the gift was sent */
+    gift_upgrade_sent: GiftInfo;
+  }
   export interface ConnectedWebsiteMessage extends ServiceMessage {
     /** The domain name of the website on which the user has logged in. More about Telegram Login » */
     connected_website: string;
@@ -391,6 +395,7 @@ export type ServiceMessageBundle =
   | Message.ChatSharedMessage
   | Message.GiftMessage
   | Message.UniqueGiftMessage
+  | Message.GiftUpgradeSentMessage
   | Message.ConnectedWebsiteMessage
   | Message.WriteAccessAllowedMessage
   | Message.PassportDataMessage
@@ -1121,8 +1126,10 @@ export interface ChecklistTask {
   text: string;
   /** Special entities that appear in the task text */
   text_entities?: MessageEntity[];
-  /** User that completed the task; omitted if the task wasn't completed */
+  /** User that completed the task; omitted if the task wasn't completed by a user */
   completed_by_user?: User;
+  /** Chat that completed the task; omitted if the task wasn't completed by a chat */
+  completed_by_chat?: Chat;
   /** Point in time (Unix timestamp) when the task was completed; 0 if the task wasn't completed */
   completion_date?: number;
 }
@@ -1474,6 +1481,8 @@ export interface ForumTopicCreated {
   icon_color: number;
   /** Unique identifier of the custom emoji shown as the topic icon */
   icon_custom_emoji_id?: string;
+  /** True, if the name of the topic wasn't specified explicitly by its creator and likely needs to be changed by the bot */
+  is_name_implicit?: true;
 }
 
 /** This object represents a service message about an edited forum topic. */
@@ -1540,8 +1549,10 @@ export interface GiftInfo {
   owned_gift_id?: string;
   /** Number of Telegram Stars that can be claimed by the receiver by converting the gift; omitted if conversion to Telegram Stars is impossible */
   convert_star_count?: number;
-  /** Number of Telegram Stars that were prepaid by the sender for the ability to upgrade the gift */
+  /** Number of Telegram Stars that were prepaid for the ability to upgrade the gift */
   prepaid_upgrade_star_count?: number;
+  /** True, if the gift's upgrade was purchased after the gift was sent */
+  is_upgrade_separate?: true;
   /** True, if the gift can be upgraded to a unique gift */
   can_be_upgraded?: boolean;
   /** Text of the message that was added to the gift */
@@ -1550,16 +1561,20 @@ export interface GiftInfo {
   entities?: MessageEntity[];
   /** True, if the sender and gift text are shown only to the gift receiver; otherwise, everyone will be able to see them */
   is_private?: boolean;
+  /** Unique number reserved for this gift when upgraded. See the number field in UniqueGift */
+  unique_gift_number?: number;
 }
 
 /** Describes a service message about a unique gift that was sent or received. */
 export interface UniqueGiftInfo {
   /** Information about the gift */
   gift: UniqueGift;
-  /** Origin of the gift. Currently, either “upgrade” for gifts upgraded from regular gifts, “transfer” for gifts transferred from other users or channels, or “resale” for gifts bought from other users */
-  origin: "upgrade" | "transfer" | "resale";
-  /** For gifts bought from other users, the price paid for the gift */
-  last_resale_star_count?: number;
+  /** Origin of the gift. Currently, either “upgrade” for gifts upgraded from regular gifts, “transfer” for gifts transferred from other users or channels, “resale” for gifts bought from other users, “gifted_upgrade” for upgrades purchased after the gift was sent, or “offer” for gifts bought or sold through gift purchase offers */
+  origin: "upgrade" | "transfer" | "resale" | "gifted_upgrade" | "offer";
+  /** For gifts bought from other users, the currency in which the payment for the gift was done. Currently, one of “XTR” for Telegram Stars or “TON” for toncoins. */
+  last_resale_currency?: "XTR" | "TON";
+  /** For gifts bought from other users, the price paid for the gift in either Telegram Stars or nanotoncoins */
+  last_resale_amount?: number;
   /** Unique identifier of the received gift for the bot; only present for gifts received on behalf of business accounts */
   owned_gift_id?: string;
   /** Number of Telegram Stars that must be paid to transfer the gift; omitted if the bot cannot transfer the gift */

--- a/message.ts
+++ b/message.ts
@@ -1,8 +1,8 @@
 // deno-lint-ignore-file no-irregular-whitespace
 import type {
+  Chat,
   ChatOwnerChanged,
   ChatOwnerLeft,
-  Chat,
   DirectMessagesTopic,
   File,
   Gift,
@@ -718,6 +718,10 @@ export declare namespace MessageEntity {
   }
   export interface DateTime extends Abstract {
     type: "date_time";
+    /** Unix time associated with the entity */
+    unix_time?: number;
+    /** String that defines the formatting of the date and time */
+    date_time_format?: string;
   }
 }
 
@@ -748,7 +752,7 @@ export type MessageEntity =
 export interface TextQuote {
   /** Text of the quoted part of a message that is replied to by the given message */
   text: string;
-  /** Special entities that appear in the quote. Currently, only bold, italic, underline, strikethrough, spoiler, and custom_emoji entities are kept in quotes. */
+  /** Special entities that appear in the quote. Currently, only bold, italic, underline, strikethrough, spoiler, custom_emoji, and date_time entities are kept in quotes. */
   entities?: MessageEntity[];
   /** Approximate quote position in the original message in UTF-16 code units as specified by the sender */
   position: number;
@@ -901,7 +905,7 @@ export interface ReplyParameters {
   chat_id?: number | string;
   /** Pass True if the message should be sent even if the specified message to be replied to is not found. Always False for replies in another chat or forum topic. Always True for messages sent on behalf of a business account. */
   allow_sending_without_reply?: boolean;
-  /** Quoted part of the message to be replied to; 0-1024 characters after entities parsing. The quote must be an exact substring of the message to be replied to, including bold, italic, underline, strikethrough, spoiler, and custom_emoji entities. The message will fail to send if the quote isn't found in the original message. */
+  /** Quoted part of the message to be replied to; 0-1024 characters after entities parsing. The quote must be an exact substring of the message to be replied to, including bold, italic, underline, strikethrough, spoiler, custom_emoji, and date_time entities. The message will fail to send if the quote isn't found in the original message. */
   quote?: string;
   /** Mode for parsing entities in the quote. See formatting options for more details. */
   quote_parse_mode?: ParseMode;

--- a/methods.ts
+++ b/methods.ts
@@ -27,6 +27,7 @@ import type {
   SuggestedPostParameters,
   UserChatBoosts,
   UserFromGetMe,
+  UserProfileAudios,
   UserProfilePhotos,
   WebhookInfo,
 } from "./manage.ts";
@@ -981,6 +982,16 @@ export type ApiMethods<F> = {
     limit?: number;
   }): UserProfilePhotos;
 
+  /** Use this method to get a list of profile audios for a user. Returns a UserProfileAudios object. */
+  getUserProfileAudios(args: {
+    /** Unique identifier of the target user */
+    user_id: number;
+    /** Sequential number of the first audio to be returned. By default, all audios are returned. */
+    offset?: number;
+    /** Limits the number of audios to be retrieved. Values between 1-100 are accepted. Defaults to 100. */
+    limit?: number;
+  }): UserProfileAudios;
+
   /** Changes the emoji status for a given user that previously allowed the bot to manage their emoji status via the Mini App method requestEmojiStatusAccess. Returns True on success. */
   setUserEmojiStatus(args: {
     /** Unique identifier of the target user */
@@ -1309,7 +1320,7 @@ export type ApiMethods<F> = {
 
   /** Use this method to get custom emoji stickers, which can be used as a forum topic icon by any user. Requires no parameters. Returns an Array of Sticker objects. */
   getForumTopicIconStickers(): Sticker[];
-  /** Use this method to create a topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns information about the created topic as a ForumTopic object. */
+  /** Use this method to create a topic in a forum supergroup chat or a private chat with a user. In the case of a supergroup chat the bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator right. Returns information about the created topic as a ForumTopic object. */
   createForumTopic(args: {
     /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
@@ -1506,6 +1517,15 @@ export type ApiMethods<F> = {
     /** A two-letter ISO 639-1 language code or an empty string */
     language_code?: string;
   }): BotShortDescription;
+
+  /** Changes the profile photo of the bot. Returns True on success. */
+  setMyProfilePhoto(args: {
+    /** The new profile photo to set */
+    photo: InputProfilePhoto<F>;
+  }): true;
+
+  /** Removes the profile photo of the bot. Requires no parameters. Returns True on success. */
+  removeMyProfilePhoto(): true;
 
   /** Use this method to change the bot's menu button in a private chat, or the default menu button. Returns True on success. */
   setChatMenuButton(args: {

--- a/methods.ts
+++ b/methods.ts
@@ -151,7 +151,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -187,7 +187,7 @@ export type ApiMethods<F> = {
   forwardMessage(args: {
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -199,6 +199,8 @@ export type ApiMethods<F> = {
     disable_notification?: boolean;
     /** Protects the contents of the forwarded message from forwarding and saving */
     protect_content?: boolean;
+    /** Unique identifier of the message effect to be added to the message; only available when forwarding to private chats */
+    message_effect_id?: string;
     /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
     suggested_post_parameters?: SuggestedPostParameters;
     /** Message identifier in the chat specified in from_chat_id */
@@ -209,7 +211,7 @@ export type ApiMethods<F> = {
   forwardMessages(args: {
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -227,7 +229,7 @@ export type ApiMethods<F> = {
   copyMessage(args: {
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -251,6 +253,8 @@ export type ApiMethods<F> = {
     protect_content?: boolean;
     /** Pass True to allow up to 1000 messages per second, ignoring broadcasting limits for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance */
     allow_paid_broadcast?: boolean;
+    /** Unique identifier of the message effect to be added to the message; only available when copying to private chats */
+    message_effect_id?: string;
     /** An object containing the parameters of the suggested post to send; for direct messages chats only. If the message is sent as a reply to another suggested post, then that suggested post is automatically declined. */
     suggested_post_parameters?: SuggestedPostParameters;
     /** Description of the message to reply to */
@@ -267,7 +271,7 @@ export type ApiMethods<F> = {
   copyMessages(args: {
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -289,7 +293,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -331,7 +335,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -377,7 +381,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -419,7 +423,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -475,7 +479,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -525,7 +529,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -566,7 +570,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -604,7 +608,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`). If the chat is a channel, all Telegram Star proceeds from this media will be credited to the chat's balance. Otherwise, they will be credited to the bot's balance. */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -646,7 +650,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -682,7 +686,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -724,7 +728,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -770,7 +774,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -808,7 +812,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`). Polls can't be sent to channel direct messages chats. */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Poll question, 1-300 characters */
     question: string;
@@ -886,7 +890,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -912,6 +916,22 @@ export type ApiMethods<F> = {
       | ForceReply;
   }): Message.DiceMessage & Message.BusinessSentMessage;
 
+  /** Use this method to stream a partial message to a user while the message is being generated; supported only for bots with forum topic mode enabled. Returns True on success. */
+  sendMessageDraft(args: {
+    /** Unique identifier for the target private chat */
+    chat_id: number;
+    /** Unique identifier for the target message thread */
+    message_thread_id?: number;
+    /** Unique identifier of the message draft; must be non-zero. Changes of drafts with the same identifier are animated */
+    draft_id: number;
+    /** Text of the message to be sent, 1-4096 characters after entities parsing */
+    text: string;
+    /** Mode for parsing entities in the message text. See formatting options for more details. */
+    parse_mode?: ParseMode;
+    /** A JSON-serialized list of special entities that appear in message text, which can be specified instead of parse_mode */
+    entities?: MessageEntity[];
+  }): true;
+
   /** Use this method when you need to tell the user that something is happening on the bot's side. The status is set for 5 seconds or less (when a message arrives from your bot, Telegram clients clear its typing status). Returns True on success.
 
   Example: The ImageBot needs some time to process a request and upload the image. Instead of sending a text message along the lines of "Retrieving image, please wait...", the bot may use sendChatAction with action = upload_photo. The user will see a "sending photo" status for the bot.
@@ -922,7 +942,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`). Channel chats and channel direct messages chats aren't supported. */
     chat_id: number | string;
-    /** Unique identifier for the target message thread; for supergroups only */
+    /** Unique identifier for the target message thread or topic of a forum; for supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Type of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_voice or upload_voice for voice notes, upload_document for general files, choose_sticker for stickers, find_location for location data, record_video_note or upload_video_note for video notes. */
     action:
@@ -1307,7 +1327,7 @@ export type ApiMethods<F> = {
     icon_custom_emoji_id?: string;
   }): ForumTopic;
 
-  /** Use this method to edit name and icon of a topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic. Returns True on success. */
+  /** Use this method to edit name and icon of a topic in a forum supergroup chat or a private chat with a user. In the case of a supergroup chat the bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights, unless it is the creator of the topic. Returns True on success. */
   editForumTopic(args: {
     /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
@@ -1335,7 +1355,7 @@ export type ApiMethods<F> = {
     message_thread_id: number;
   }): true;
 
-  /** Use this method to delete a forum topic along with all its messages in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_delete_messages administrator rights. Returns True on success. */
+  /** Use this method to delete a forum topic along with all its messages in a forum supergroup chat or a private chat with a user. In the case of a supergroup chat the bot must be an administrator in the chat for this to work and must have the can_delete_messages administrator rights. Returns True on success. */
   deleteForumTopic(args: {
     /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
@@ -1343,7 +1363,7 @@ export type ApiMethods<F> = {
     message_thread_id: number;
   }): true;
 
-  /** Use this method to clear the list of pinned messages in a forum topic. The bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup. Returns True on success. */
+  /** Use this method to clear the list of pinned messages in a forum topic in a forum supergroup chat or a private chat with a user. In the case of a supergroup chat the bot must be an administrator in the chat for this to work and must have the can_pin_messages administrator right in the supergroup. Returns True on success. */
   unpinAllForumTopicMessages(args: {
     /** Unique identifier for the target chat or username of the target supergroup (in the format `@supergroupusername`) */
     chat_id: number | string;
@@ -1655,13 +1675,65 @@ export type ApiMethods<F> = {
     exclude_saved?: boolean;
     /** Pass True to exclude gifts that can be purchased an unlimited number of times */
     exclude_unlimited?: boolean;
-    /** Pass True to exclude gifts that can be purchased a limited number of times */
-    exclude_limited?: boolean;
+    /** Pass True to exclude gifts that can be purchased a limited number of times and can be upgraded to unique */
+    exclude_limited_upgradable?: boolean;
+    /** Pass True to exclude gifts that can be purchased a limited number of times and can't be upgraded to unique */
+    exclude_limited_non_upgradable?: boolean;
+    /** Pass True to exclude unique gifts */
+    exclude_unique?: boolean;
+    /** Pass True to exclude gifts that were assigned from the TON blockchain and can't be resold or transferred in Telegram */
+    exclude_from_blockchain?: boolean;
+    /** Pass True to sort results by gift price instead of send date. Sorting is applied before pagination. */
+    sort_by_price?: boolean;
+    /** Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results */
+    offset?: string;
+    /** The maximum number of gifts to be returned; 1-100. Defaults to 100 */
+    limit?: number;
+  }): OwnedGifts;
+
+  /** Returns the gifts owned and hosted by a user. Returns OwnedGifts on success. */
+  getUserGifts(args: {
+    /** Unique identifier of the user */
+    user_id: number;
+    /** Pass True to exclude gifts that can be purchased an unlimited number of times */
+    exclude_unlimited?: boolean;
+    /** Pass True to exclude gifts that can be purchased a limited number of times and can be upgraded to unique */
+    exclude_limited_upgradable?: boolean;
+    /** Pass True to exclude gifts that can be purchased a limited number of times and can't be upgraded to unique */
+    exclude_limited_non_upgradable?: boolean;
+    /** Pass True to exclude gifts that were assigned from the TON blockchain and can't be resold or transferred in Telegram */
+    exclude_from_blockchain?: boolean;
     /** Pass True to exclude unique gifts */
     exclude_unique?: boolean;
     /** Pass True to sort results by gift price instead of send date. Sorting is applied before pagination. */
     sort_by_price?: boolean;
-    /** Offset of the first entry to return as received from the previous request; use empty string to get the first chunk of results */
+    /** Offset of the first entry to return as received from the previous request; use an empty string to get the first chunk of results */
+    offset?: string;
+    /** The maximum number of gifts to be returned; 1-100. Defaults to 100 */
+    limit?: number;
+  }): OwnedGifts;
+
+  /** Returns the gifts owned by a chat. Returns OwnedGifts on success. */
+  getChatGifts(args: {
+    /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
+    chat_id: number | string;
+    /** Pass True to exclude gifts that aren't saved to the chat's profile page. Always True, unless the bot has the can_post_messages administrator right in the channel. */
+    exclude_unsaved?: boolean;
+    /** Pass True to exclude gifts that are saved to the chat's profile page. Always False, unless the bot has the can_post_messages administrator right in the channel. */
+    exclude_saved?: boolean;
+    /** Pass True to exclude gifts that can be purchased an unlimited number of times */
+    exclude_unlimited?: boolean;
+    /** Pass True to exclude gifts that can be purchased a limited number of times and can be upgraded to unique */
+    exclude_limited_upgradable?: boolean;
+    /** Pass True to exclude gifts that can be purchased a limited number of times and can't be upgraded to unique */
+    exclude_limited_non_upgradable?: boolean;
+    /** Pass True to exclude gifts that were assigned from the TON blockchain and can't be resold or transferred in Telegram */
+    exclude_from_blockchain?: boolean;
+    /** Pass True to exclude unique gifts */
+    exclude_unique?: boolean;
+    /** Pass True to sort results by gift price instead of send date. Sorting is applied before pagination. */
+    sort_by_price?: boolean;
+    /** Offset of the first entry to return as received from the previous request; use an empty string to get the first chunk of results */
     offset?: string;
     /** The maximum number of gifts to be returned; 1-100. Defaults to 100 */
     limit?: number;
@@ -1715,6 +1787,22 @@ export type ApiMethods<F> = {
     caption_entities?: MessageEntity[];
     /** A list of clickable areas to be shown on the story */
     areas?: StoryArea[];
+    /** Pass True to keep the story accessible after it expires */
+    post_to_chat_page?: boolean;
+    /** Pass True if the content of the story must be protected from forwarding and screenshotting */
+    protect_content?: boolean;
+  }): Story;
+
+  /** Reposts a story on behalf of a business account from another business account. Both business accounts must be managed by the same bot, and the story on the source account must have been posted (or reposted) by the bot. Requires the can_manage_stories business bot right for both business accounts. Returns Story on success. */
+  repostStory(args: {
+    /** Unique identifier of the business connection */
+    business_connection_id: string;
+    /** Unique identifier of the chat which posted the story that should be reposted */
+    from_chat_id: number;
+    /** Unique identifier of the story that should be reposted */
+    from_story_id: number;
+    /** Period after which the story is moved to the archive, in seconds; must be one of 6 * 3600, 12 * 3600, 86400, or 2 * 86400 */
+    active_period: 21600 | 43200 | 86400 | 172800;
     /** Pass True to keep the story accessible after it expires */
     post_to_chat_page?: boolean;
     /** Pass True if the content of the story must be protected from forwarding and screenshotting */
@@ -1973,7 +2061,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -2183,7 +2271,7 @@ export type ApiMethods<F> = {
   sendInvoice(args: {
     /** Unique identifier for the target chat or username of the target channel (in the format `@channelusername`) */
     chat_id: number | string;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Identifier of the direct messages topic to which the message will be sent; required if the message is sent to a direct messages chat */
     direct_messages_topic_id?: number;
@@ -2360,7 +2448,7 @@ export type ApiMethods<F> = {
     business_connection_id?: string;
     /** Unique identifier for the target chat */
     chat_id: number;
-    /** Unique identifier for the target message thread (topic) of the forum; for forum supergroups only */
+    /** Unique identifier for the target message thread (topic) of a forum; for forum supergroups and private chats of bots with forum topic mode enabled only */
     message_thread_id?: number;
     /** Short name of the game, serves as the unique identifier for the game. Set up your games via BotFather. */
     game_short_name: string;

--- a/methods.ts
+++ b/methods.ts
@@ -3,6 +3,8 @@ import type { InlineQueryResult, InlineQueryResultsButton } from "./inline.ts";
 import type {
   ForceReply,
   InlineKeyboardMarkup,
+  KeyboardButton,
+  PreparedKeyboardButton,
   ReplyKeyboardMarkup,
   ReplyKeyboardRemove,
 } from "./markup.ts";
@@ -827,20 +829,34 @@ export type ApiMethods<F> = {
     is_anonymous?: boolean;
     /** Poll type, “quiz” or “regular”, defaults to “regular” */
     type?: "quiz" | "regular";
-    /** True, if the poll allows multiple answers, ignored for polls in quiz mode, defaults to False */
+    /** True, if the poll allows multiple answers, defaults to False */
     allows_multiple_answers?: boolean;
-    /** 0-based identifier of the correct answer option, required for polls in quiz mode */
-    correct_option_id?: number;
+    /** Pass True if the poll allows changing chosen answer options */
+    allows_revoting?: boolean;
+    /** Pass True if the poll options must be shown in random order */
+    shuffle_options?: boolean;
+    /** Pass True if answer options can be added to the poll after creation */
+    allow_adding_options?: boolean;
+    /** Pass True if poll results must be shown only after the poll closes */
+    hide_results_until_closes?: boolean;
+    /** 0-based identifiers of the correct answer options, required for polls in quiz mode */
+    correct_option_ids?: number[];
     /** Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters with at most 2 line feeds after entities parsing */
     explanation?: string;
     /** Mode for parsing entities in the explanation. See formatting options for more details. */
     explanation_parse_mode?: ParseMode;
     /** A list of special entities that appear in the poll explanation. It can be specified instead of explanation_parse_mode */
     explanation_entities?: MessageEntity[];
-    /** Amount of time in seconds the poll will be active after creation, 5-600. Can't be used together with close_date. */
+    /** Amount of time in seconds the poll will be active after creation, 5-2628000. Can't be used together with close_date. */
     open_period?: number;
-    /** Point in time (Unix timestamp) when the poll will be automatically closed. Must be at least 5 and no more than 600 seconds in the future. Can't be used together with open_period. */
+    /** Point in time (Unix timestamp) when the poll will be automatically closed. Must be at least 5 and no more than 2628000 seconds in the future. Can't be used together with open_period. */
     close_date?: number;
+    /** Description of the poll */
+    description?: string;
+    /** Mode for parsing entities in the poll description */
+    description_parse_mode?: ParseMode;
+    /** Special entities that appear in the poll description */
+    description_entities?: MessageEntity[];
     /** Pass True if the poll needs to be immediately closed. This can be useful for poll preview. */
     is_closed?: boolean;
     /** Sends the message silently. Users will receive a notification with no sound. */
@@ -1098,6 +1114,16 @@ export type ApiMethods<F> = {
     user_id: number;
     /** New custom title for the administrator; 0-16 characters, emoji are not allowed */
     custom_title: string;
+  }): true;
+
+  /** Use this method to set a tag for a regular member in a group or a supergroup. */
+  setChatMemberTag(args: {
+    /** Unique identifier for the target chat or username of the target supergroup */
+    chat_id: number | string;
+    /** Unique identifier of the target user */
+    user_id: number;
+    /** New tag for the member; 0-16 characters, emoji are not allowed */
+    tag?: string;
   }): true;
 
   /** Use this method to ban a channel chat in a supergroup or a channel. Until the chat is unbanned, the owner of the banned chat won't be able to send messages on behalf of any of their channels. The bot must be an administrator in the supergroup or channel for this to work and must have the appropriate administrator rights. Returns True on success. */
@@ -1449,6 +1475,18 @@ export type ApiMethods<F> = {
     /** Unique identifier of the business connection */
     business_connection_id?: string;
   }): BusinessConnection;
+
+  /** Use this method to get the token of a managed bot. Returns the token as String on success. */
+  getManagedBotToken(args: {
+    /** User identifier of the managed bot whose token will be returned */
+    user_id: number;
+  }): string;
+
+  /** Use this method to revoke the current token of a managed bot and generate a new one. Returns the new token as String on success. */
+  replaceManagedBotToken(args: {
+    /** User identifier of the managed bot whose token will be replaced */
+    user_id: number;
+  }): string;
 
   /** Use this method to change the list of the bot's commands. See https://core.telegram.org/bots#commands for more details about bot commands. Returns True on success. */
   setMyCommands(args: {
@@ -1983,6 +2021,20 @@ export type ApiMethods<F> = {
     | (Update.Edited & Message.LocationMessage & Message.BusinessSentMessage)
     | true;
 
+  /** Use this method to edit a checklist on behalf of a connected business account. On success, the edited Message is returned. */
+  editMessageChecklist(args: {
+    /** Unique identifier of the business connection on behalf of which the message will be sent */
+    business_connection_id: string;
+    /** Unique identifier for the target chat */
+    chat_id: number;
+    /** Unique identifier for the target message */
+    message_id: number;
+    /** An object for the new checklist */
+    checklist: InputChecklist;
+    /** An object for the new inline keyboard for the message */
+    reply_markup?: InlineKeyboardMarkup;
+  }): Update.Edited & Message.ChecklistMessage & Message.BusinessSentMessage;
+
   /** Use this method to edit only the reply markup of messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned. Note that business messages that were not sent by the bot and do not contain an inline keyboard can only be edited within 48 hours from the time they were sent. */
   editMessageReplyMarkup(args: {
     /** Unique identifier of the business connection on behalf of which the message to be edited was sent */
@@ -2286,6 +2338,14 @@ export type ApiMethods<F> = {
     /** Pass True if the message can be sent to channel chats */
     allow_channel_chats?: boolean;
   }): PreparedInlineMessage;
+
+  /** Stores a keyboard button that can be used by a user within a Mini App. */
+  savePreparedKeyboardButton(args: {
+    /** Unique identifier of the target user that can use the button */
+    user_id: number;
+    /** A keyboard button to be saved */
+    button: KeyboardButton;
+  }): PreparedKeyboardButton;
 
   /** Use this method to send invoices. On success, the sent Message is returned. */
   sendInvoice(args: {

--- a/methods.ts
+++ b/methods.ts
@@ -1102,7 +1102,7 @@ export type ApiMethods<F> = {
     can_pin_messages?: boolean;
     /** Pass True if the user is allowed to create, rename, close, and reopen forum topics; supergroups only */
     can_manage_topics?: boolean;
-    /** Pass True if the administrator can manage tags; for supergroups only */
+    /** Pass True if the administrator can edit the tags of regular members; for groups and supergroups only */
     can_manage_tags?: boolean;
     /** Pass True if the administrator can manage direct messages within the channel and decline suggested posts; for channels only */
     can_manage_direct_messages?: boolean;
@@ -1605,9 +1605,9 @@ export type ApiMethods<F> = {
     star_count: 1000 | 1500 | 2500;
     /** Text that will be shown along with the service message about the subscription; 0-128 characters */
     text?: string;
-    /** Mode for parsing entities in the text. See formatting options for more details. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored. */
+    /** Mode for parsing entities in the text. See formatting options for more details. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, “custom_emoji”, and “date_time” are ignored. */
     text_parse_mode?: ParseMode;
-    /** A list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored. */
+    /** A list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, “custom_emoji”, and “date_time” are ignored. */
     text_entities?: MessageEntity[];
   }): true;
 
@@ -2123,9 +2123,9 @@ export type ApiMethods<F> = {
     pay_for_upgrade?: boolean;
     /** Text that will be shown along with the gift; 0-255 characters */
     text?: string;
-    /** Mode for parsing entities in the text. See formatting options for more details. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored. */
+    /** Mode for parsing entities in the text. See formatting options for more details. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, “custom_emoji”, and “date_time” are ignored. */
     text_parse_mode?: ParseMode;
-    /** A list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored. */
+    /** A list of special entities that appear in the gift text. It can be specified instead of text_parse_mode. Entities other than “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, “custom_emoji”, and “date_time” are ignored. */
     text_entities?: MessageEntity[];
   }): true;
 
@@ -2345,8 +2345,11 @@ export type ApiMethods<F> = {
   savePreparedKeyboardButton(args: {
     /** Unique identifier of the target user that can use the button */
     user_id: number;
-    /** A keyboard button to be saved */
-    button: KeyboardButton;
+    /** A request_users, request_chat, or request_managed_bot keyboard button to be saved */
+    button:
+      | KeyboardButton.RequestUsers
+      | KeyboardButton.RequestChat
+      | KeyboardButton.RequestManagedBot;
   }): PreparedKeyboardButton;
 
   /** Use this method to send invoices. On success, the sent Message is returned. */

--- a/methods.ts
+++ b/methods.ts
@@ -1102,6 +1102,8 @@ export type ApiMethods<F> = {
     can_pin_messages?: boolean;
     /** Pass True if the user is allowed to create, rename, close, and reopen forum topics; supergroups only */
     can_manage_topics?: boolean;
+    /** Pass True if the administrator can manage tags; for supergroups only */
+    can_manage_tags?: boolean;
     /** Pass True if the administrator can manage direct messages within the channel and decline suggested posts; for channels only */
     can_manage_direct_messages?: boolean;
   }): true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,22 +9,23 @@
       "version": "9.6.0",
       "license": "MIT",
       "devDependencies": {
-        "deno-bin": "^2.1.6"
+        "deno-bin": "^2.2.7"
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
-      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/deno-bin": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/deno-bin/-/deno-bin-2.1.6.tgz",
-      "integrity": "sha512-K05LNOnAWE58JPXmH50sfmoaOTnT9JHKtCtVmYAIHcbkNiILQVO5jMvm5+Ti258tMmnPq565cKryB8bdO2CIzg==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/deno-bin/-/deno-bin-2.2.7.tgz",
+      "integrity": "sha512-ANCqji3OqD0Voji5OtUElCFRhcp1Wt6d2LUMR+jlOXkIN/MqL8BgzHFMi3a5e8YnB7IEpxsR/O3Yd+wkQXcc9g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telegraf/types",
-  "version": "8.2.0",
+  "version": "9.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telegraf/types",
-      "version": "8.2.0",
+      "version": "9.3.0",
       "license": "MIT",
       "devDependencies": {
         "deno-bin": "^2.1.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telegraf/types",
-  "version": "9.4.0",
+  "version": "9.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telegraf/types",
-      "version": "9.4.0",
+      "version": "9.6.0",
       "license": "MIT",
       "devDependencies": {
         "deno-bin": "^2.1.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telegraf/types",
-  "version": "9.3.0",
+  "version": "9.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telegraf/types",
-      "version": "9.3.0",
+      "version": "9.4.0",
       "license": "MIT",
       "devDependencies": {
         "deno-bin": "^2.1.6"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "index.js"
   ],
   "devDependencies": {
-    "deno-bin": "^2.1.6"
+    "deno-bin": "^2.2.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@telegraf/types",
   "private": false,
-  "version": "9.4.0",
+  "version": "9.6.0",
   "description": "Type declarations for the Telegram API",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@telegraf/types",
   "private": false,
-  "version": "9.3.0",
+  "version": "9.4.0",
   "description": "Type declarations for the Telegram API",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@telegraf/types",
   "private": false,
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Type declarations for the Telegram API",
   "main": "index.js",
   "repository": {

--- a/update.ts
+++ b/update.ts
@@ -7,6 +7,7 @@ import type {
   ChatBoostUpdated,
   ChatJoinRequest,
   ChatMemberUpdated,
+  ManagedBotUpdated,
   MessageReactionCountUpdated,
   MessageReactionUpdated,
   User,
@@ -160,6 +161,10 @@ export declare namespace Update {
     /** A boost was removed from a chat. The bot must be an administrator in the chat to receive these updates. */
     removed_chat_boost: ChatBoostRemoved;
   }
+  export interface ManagedBotUpdate extends AbstractUpdate {
+    /** A new bot was created to be managed by the bot, or token or owner of a managed bot was changed */
+    managed_bot: ManagedBotUpdated;
+  }
 }
 
 /** This object represents an incoming update.
@@ -186,4 +191,5 @@ export type Update =
   | Update.ShippingQueryUpdate
   | Update.ChatJoinRequestUpdate
   | Update.ChatBoostUpdate
-  | Update.RemovedChatBoostUpdate;
+  | Update.RemovedChatBoostUpdate
+  | Update.ManagedBotUpdate;


### PR DESCRIPTION
## Summary

- updates @telegraf/types to Bot API 9.6
- adds Bot API 9.3-9.6 methods, objects, fields, and parameter changes
- preserves existing keyboard button aliases while adding managed bot keyboard support
- tightens Bot API 9.6 details for date_time entities, getMe-only bot management fields, and prepared keyboard buttons

## Validation

- `deno fmt --check manage.ts markup.ts message.ts methods.ts update.ts`
- `deno lint`
- `deno task check`
- `npm pack --dry-run`
- compared methods against the live Telegram Bot API docs: 169 official methods, 169 typed methods, no missing or extra methods

## Notes

- `.github/workflows/release.yml` is formatted so full-repo `deno fmt --check` passes.
